### PR TITLE
Refactor: Cleaning up models and Index

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,14 @@
  * @module markdown-transform
  */
 
+module.exports.Logger = require('./lib/Logger');
+module.exports.Stack = require('./lib/Stack');
+
 module.exports.CommonmarkParser = require('./lib/CommonmarkParser');
 module.exports.CommonmarkToString = require('./lib/CommonmarkToString');
+module.exports.ToStringVisitor = require('./lib/ToStringVisitor');
+
 module.exports.CommonmarkToAP = require('./lib/CommonmarkToAP');
 module.exports.CommonmarkFromAP = require('./lib/CommonmarkFromAP');
-module.exports.ToStringVisitor = require('./lib/ToStringVisitor');
 module.exports.ToAPVisitor = require('./lib/ToAPVisitor');
 module.exports.FromAPVisitor = require('./lib/FromAPVisitor');
-module.exports.Stack = require('./lib/Stack');

--- a/index.js
+++ b/index.js
@@ -21,5 +21,9 @@
 
 module.exports.CommonmarkParser = require('./lib/CommonmarkParser');
 module.exports.CommonmarkToString = require('./lib/CommonmarkToString');
+module.exports.CommonmarkToAP = require('./lib/CommonmarkToAP');
+module.exports.CommonmarkFromAP = require('./lib/CommonmarkFromAP');
 module.exports.ToStringVisitor = require('./lib/ToStringVisitor');
+module.exports.ToAPVisitor = require('./lib/ToAPVisitor');
+module.exports.FromAPVisitor = require('./lib/FromAPVisitor');
 module.exports.Stack = require('./lib/Stack');

--- a/src/CommonmarkFromAP.js
+++ b/src/CommonmarkFromAP.js
@@ -20,7 +20,7 @@ const Serializer = require('composer-concerto').Serializer;
 
 const FromAPVisitor = require('./FromAPVisitor');
 const CommonmarkToString = require('./CommonmarkToString');
-const { commonmarkModel } = require('./Models');
+const { commonmarkModel, ciceromarkModel } = require('./Models');
 
 /**
  * Converts a commonmark document to a markdown string
@@ -30,7 +30,8 @@ const { commonmarkModel } = require('./Models');
 function commonMarkFromAP(concertoObject) {
     // Setup for validation
     const modelManager = new ModelManager();
-    modelManager.addModelFile( commonmarkModel, 'commonmark.cto');
+    modelManager.addModelFile(commonmarkModel, 'commonmark.cto');
+    modelManager.addModelFile(ciceromarkModel, 'ciceromark.cto');
     const factory = new Factory(modelManager);
     const serializer = new Serializer(factory, modelManager);
 

--- a/src/CommonmarkParser.js
+++ b/src/CommonmarkParser.js
@@ -21,7 +21,7 @@ const Factory = require('composer-concerto').Factory;
 const Serializer = require('composer-concerto').Serializer;
 const Stack = require('./Stack');
 const { DOMParser } = require('xmldom');
-const { NS_PREFIX, commonmarkModel } = require('./Models');
+const { COMMON_NS_PREFIX, commonmarkModel } = require('./Models');
 
 /**
  * Parses markdown using the commonmark parser into the
@@ -40,7 +40,7 @@ class CommonmarkParser {
     constructor(options) {
         this.options = options;
         const modelManager = new ModelManager();
-        modelManager.addModelFile( commonmarkModel, 'commonmark.cto');
+        modelManager.addModelFile(commonmarkModel, 'commonmark.cto');
         const factory = new Factory(modelManager);
         this.serializer = new Serializer(factory, modelManager);
     }
@@ -60,11 +60,11 @@ class CommonmarkParser {
      * @return {boolean} whether it's a leaf node
      */
     static isLeafNode(json) {
-        return (json.$class === (NS_PREFIX + 'Text') ||
-                json.$class === (NS_PREFIX + 'CodeBlock') ||
-                json.$class === (NS_PREFIX + 'HtmlInline') ||
-                json.$class === (NS_PREFIX + 'HtmlBlock') ||
-                json.$class === (NS_PREFIX + 'Code'));
+        return (json.$class === (COMMON_NS_PREFIX + 'Text') ||
+                json.$class === (COMMON_NS_PREFIX + 'CodeBlock') ||
+                json.$class === (COMMON_NS_PREFIX + 'HtmlInline') ||
+                json.$class === (COMMON_NS_PREFIX + 'HtmlBlock') ||
+                json.$class === (COMMON_NS_PREFIX + 'Code'));
     }
 
     /**
@@ -73,9 +73,9 @@ class CommonmarkParser {
      * @return {boolean} whether it's a leaf node
      */
     static isHtmlNode(json) {
-        return (json.$class === (NS_PREFIX + 'CodeBlock') ||
-                json.$class === (NS_PREFIX + 'HtmlInline') ||
-                json.$class === (NS_PREFIX + 'HtmlBlock'));
+        return (json.$class === (COMMON_NS_PREFIX + 'CodeBlock') ||
+                json.$class === (COMMON_NS_PREFIX + 'HtmlInline') ||
+                json.$class === (COMMON_NS_PREFIX + 'HtmlBlock'));
     }
 
     /**
@@ -107,7 +107,7 @@ class CommonmarkParser {
                     const tagInfo = CommonmarkParser.parseHtmlBlock(head.text);
                     if (tagInfo) {
                         head.tag = {};
-                        head.tag.$class = NS_PREFIX + 'TagInfo';
+                        head.tag.$class = COMMON_NS_PREFIX + 'TagInfo';
                         head.tag.tagName = tagInfo.tag;
                         head.tag.attributeString = tagInfo.attributeString;
                         head.tag.attributes = [];
@@ -115,7 +115,7 @@ class CommonmarkParser {
                             if (tagInfo.attributes.hasOwnProperty(attName)) {
                                 const attValue = tagInfo.attributes[attName];
                                 head.tag.attributes.push({
-                                    '$class': NS_PREFIX + 'Attribute',
+                                    '$class': COMMON_NS_PREFIX + 'Attribute',
                                     'name': attName,
                                     'value': attValue,
                                 });
@@ -208,7 +208,7 @@ class CommonmarkParser {
      */
     static toClass(name) {
         const camelCased = name.replace(/_([a-z])/g, function (g) { return g[1].toUpperCase(); });
-        return NS_PREFIX + CommonmarkParser.capitalizeFirstLetter(camelCased);
+        return COMMON_NS_PREFIX + CommonmarkParser.capitalizeFirstLetter(camelCased);
     }
 
     /**

--- a/src/CommonmarkToAP.js
+++ b/src/CommonmarkToAP.js
@@ -20,7 +20,7 @@ const Serializer = require('composer-concerto').Serializer;
 
 const CommonmarkParser = require('./CommonmarkParser');
 const ToAPVisitor = require('./ToAPVisitor');
-const { commonmarkModel } = require('./Models');
+const { commonmarkModel, ciceromarkModel } = require('./Models');
 
 /**
  * Converts a commonmark document to a markdown string
@@ -33,7 +33,8 @@ function commonMarkToAP(concertoObject) {
 
     // Setup for validation
     const modelManager = new ModelManager();
-    modelManager.addModelFile( commonmarkModel, 'commonmark.cto');
+    modelManager.addModelFile(commonmarkModel, 'commonmark.cto');
+    modelManager.addModelFile(ciceromarkModel, 'ciceromark.cto');
     const factory = new Factory(modelManager);
     const serializer = new Serializer(factory, modelManager);
 

--- a/src/FromAPVisitor.js
+++ b/src/FromAPVisitor.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const { NS_PREFIX } = require('./Models');
+const { COMMON_NS_PREFIX } = require('./Models');
 
 /**
  * Converts a commonmark model instance to a markdown string.
@@ -51,11 +51,11 @@ class FromAPVisitor {
             let jsonTarget = {};
 
             // Revert to CodeBlock
-            jsonTarget.$class = NS_PREFIX + 'CodeBlock';
+            jsonTarget.$class = COMMON_NS_PREFIX + 'CodeBlock';
 
             // Get the content
             const clauseJson = parameters.serializer.toJSON(thing);
-            jsonSource.$class = NS_PREFIX + 'Document';
+            jsonSource.$class = COMMON_NS_PREFIX + 'Document';
             jsonSource.xmlns = 'http://commonmark.org/xml/1.0';
             jsonSource.nodes = clauseJson.nodes;
 
@@ -66,7 +66,7 @@ class FromAPVisitor {
 
             // Create the proper tag
             let tag = {};
-            tag.$class = NS_PREFIX + 'TagInfo';
+            tag.$class = COMMON_NS_PREFIX + 'TagInfo';
             tag.tagName = 'clause';
             tag.attributeString = attributeString;
             tag.content = content;
@@ -74,13 +74,13 @@ class FromAPVisitor {
             tag.attributes = [];
 
             let attribute1 = {};
-            attribute1.$class = NS_PREFIX + 'Attribute';
+            attribute1.$class = COMMON_NS_PREFIX + 'Attribute';
             attribute1.name = 'src';
             attribute1.value = clauseJson.src;
             tag.attributes.push(attribute1);
 
             let attribute2 = {};
-            attribute2.$class = NS_PREFIX + 'Attribute';
+            attribute2.$class = COMMON_NS_PREFIX + 'Attribute';
             attribute2.name = 'clauseid';
             attribute2.value = clauseJson.clauseid;
             tag.attributes.push(attribute2);
@@ -100,7 +100,7 @@ class FromAPVisitor {
             break;
         case 'Variable': {
             // Revert to HtmlInline
-            thing.$classDeclaration = parameters.modelManager.getType(NS_PREFIX + 'HtmlInline');
+            thing.$classDeclaration = parameters.modelManager.getType(COMMON_NS_PREFIX + 'HtmlInline');
 
             // Create the text for that document
             const content = '';
@@ -109,7 +109,7 @@ class FromAPVisitor {
 
             // Create the proper tag
             let tag = {};
-            tag.$class = NS_PREFIX + 'TagInfo';
+            tag.$class = COMMON_NS_PREFIX + 'TagInfo';
             tag.tagName = 'variable';
             tag.attributeString = attributeString;
             tag.content = content;
@@ -117,13 +117,13 @@ class FromAPVisitor {
             tag.attributes = [];
 
             let attribute1 = {};
-            attribute1.$class = NS_PREFIX + 'Attribute';
+            attribute1.$class = COMMON_NS_PREFIX + 'Attribute';
             attribute1.name = 'id';
             attribute1.value = thing.id;
             tag.attributes.push(attribute1);
 
             let attribute2 = {};
-            attribute2.$class = NS_PREFIX + 'Attribute';
+            attribute2.$class = COMMON_NS_PREFIX + 'Attribute';
             attribute2.name = 'value';
             attribute2.value = thing.value;
             tag.attributes.push(attribute2);
@@ -136,7 +136,7 @@ class FromAPVisitor {
             break;
         case 'ComputedVariable': {
             // Revert to HtmlInline
-            thing.$classDeclaration = parameters.modelManager.getType(NS_PREFIX + 'HtmlInline');
+            thing.$classDeclaration = parameters.modelManager.getType(COMMON_NS_PREFIX + 'HtmlInline');
 
             // Create the text for that document
             const content = '';
@@ -145,7 +145,7 @@ class FromAPVisitor {
 
             // Create the proper tag
             let tag = {};
-            tag.$class = NS_PREFIX + 'TagInfo';
+            tag.$class = COMMON_NS_PREFIX + 'TagInfo';
             tag.tagName = 'computed';
             tag.attributeString = attributeString;
             tag.content = content;
@@ -153,7 +153,7 @@ class FromAPVisitor {
             tag.attributes = [];
 
             let attribute1 = {};
-            attribute1.$class = NS_PREFIX + 'Attribute';
+            attribute1.$class = COMMON_NS_PREFIX + 'Attribute';
             attribute1.name = 'value';
             attribute1.value = thing.value;
             tag.attributes.push(attribute1);

--- a/src/Models.js
+++ b/src/Models.js
@@ -14,7 +14,8 @@
 
 'use strict';
 
-const NS_PREFIX = 'org.accordproject.commonmark.';
+const COMMON_NS_PREFIX = 'org.accordproject.commonmark.';
+const CICERO_NS_PREFIX = 'org.accordproject.ciceromark.';
 
 const commonmarkModel = `
 namespace org.accordproject.commonmark
@@ -58,26 +59,12 @@ concept CodeBlock extends Child {
     o TagInfo tag optional
 }
 
-concept Clause extends CodeBlock {
-    o String clauseid
-    o String src
-}
-
 concept Code extends Child {
     o String info optional
 }
 
 concept HtmlInline extends Child {
     o TagInfo tag optional
-}
-
-concept Variable extends HtmlInline {
-    o String id
-    o String value
-}
-
-concept ComputedVariable extends HtmlInline {
-    o String value
 }
 
 concept HtmlBlock extends Child {
@@ -134,4 +121,28 @@ concept Document extends Root {
 }
 `;
 
-module.exports = { NS_PREFIX, commonmarkModel };
+const ciceromarkModel = `
+namespace org.accordproject.ciceromark
+
+import org.accordproject.commonmark.*
+
+/**
+ * A model for Accord Project extensions to commonmark
+ */
+
+concept Clause extends Child {
+    o String clauseid
+    o String src
+}
+
+concept Variable extends Child {
+    o String id
+    o String value
+}
+
+concept ComputedVariable extends Child {
+    o String value
+}
+`;
+
+module.exports = { COMMON_NS_PREFIX, CICERO_NS_PREFIX, commonmarkModel, ciceromarkModel };

--- a/src/ToAPVisitor.js
+++ b/src/ToAPVisitor.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const { NS_PREFIX } = require('./Models');
+const { CICERO_NS_PREFIX } = require('./Models');
 
 /**
  * Converts a commonmark model instance to a markdown string.
@@ -52,19 +52,21 @@ class ToAPVisitor {
                 //console.log('CONTENT! : ' + tag.content);
                 if (tag.attributes[0].name === 'src' &&
                     tag.attributes[1].name === 'clauseid') {
-                    thing.$classDeclaration = parameters.modelManager.getType(NS_PREFIX + 'Clause');
+                    thing.$classDeclaration = parameters.modelManager.getType(CICERO_NS_PREFIX + 'Clause');
                     thing.src = tag.attributes[0].value;
                     thing.clauseid = tag.attributes[1].value;
                     thing.nodes = parameters.parser.parse(tag.content).nodes; // Parse text as markdown (in the nodes for the root)
                     thing.text = null; // Remove text
+                    delete thing.tag;
                 }
                 else if (tag.attributes[1].name === 'src' &&
                          tag.attributes[0].name === 'clauseid') {
-                    thing.$classDeclaration = parameters.modelManager.getType(NS_PREFIX + 'Clause');
+                    thing.$classDeclaration = parameters.modelManager.getType(CICERO_NS_PREFIX + 'Clause');
                     thing.clauseid = tag.attributes[0].value;
                     thing.src = tag.attributes[1].value;
                     thing.nodes = parameters.parser.parse(tag.content).nodes; // Parse text as markdown (in the nodes for the root)
                     thing.text = null; // Remove text
+                    delete thing.tag;
                 } else {
                     //console.log('Found Clause but without \'clauseid\' and \'src\' attributes ');
                 }
@@ -76,15 +78,17 @@ class ToAPVisitor {
                 const tag = thing.tag;
                 if (tag.attributes[0].name === 'id' &&
                     tag.attributes[1].name === 'value') {
-                    thing.$classDeclaration = parameters.modelManager.getType(NS_PREFIX + 'Variable');
+                    thing.$classDeclaration = parameters.modelManager.getType(CICERO_NS_PREFIX + 'Variable');
                     thing.id = tag.attributes[0].value;
                     thing.value = tag.attributes[1].value;
+                    delete thing.tag;
                 }
                 else if (tag.attributes[1].name === 'id' &&
                          tag.attributes[0].name === 'value') {
-                    thing.$classDeclaration = parameters.modelManager.getType(NS_PREFIX + 'Clause');
+                    thing.$classDeclaration = parameters.modelManager.getType(CICERO_NS_PREFIX + 'Clause');
                     thing.value = tag.attributes[0].value;
                     thing.id  = tag.attributes[1].value;
+                    delete thing.tag;
                 } else {
                     //console.log('Found Variable but without \'id\' and \'value\' attributes ');
                 }
@@ -92,8 +96,9 @@ class ToAPVisitor {
             if (thing.tag && thing.tag.tagName === 'computed' && thing.tag.attributes.length === 1) {
                 const tag = thing.tag;
                 if (tag.attributes[0].name === 'value') {
-                    thing.$classDeclaration = parameters.modelManager.getType(NS_PREFIX + 'ComputedVariable');
+                    thing.$classDeclaration = parameters.modelManager.getType(CICERO_NS_PREFIX + 'ComputedVariable');
                     thing.value = tag.attributes[0].value;
+                    delete thing.tag;
                 }
                 else {
                     //console.log('Found ComputedVariable but without \'value\' attributes ');

--- a/src/__snapshots__/Commonmark.test.js.snap
+++ b/src/__snapshots__/Commonmark.test.js.snap
@@ -32,6 +32,174 @@ Object {
 }
 `;
 
+exports[`markdown converts clause.md to concerto 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "This is a fixed interest loan to the amount of ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.HtmlInline",
+          "tag": Object {
+            "$class": "org.accordproject.commonmark.TagInfo",
+            "attributeString": "id = \\"loanAmount\\" value = \\"100000.0\\" ",
+            "attributes": Array [
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "id",
+                "value": "loanAmount",
+              },
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "value",
+                "value": "100000.0",
+              },
+            ],
+            "closed": true,
+            "content": "",
+            "tagName": "variable",
+          },
+          "text": "<variable id=\\"loanAmount\\" value=\\"100000.0\\"/>",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "at the yearly interest rate of ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.HtmlInline",
+          "tag": Object {
+            "$class": "org.accordproject.commonmark.TagInfo",
+            "attributeString": "id = \\"rate\\" value = \\"2.5\\" ",
+            "attributes": Array [
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "id",
+                "value": "rate",
+              },
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "value",
+                "value": "2.5",
+              },
+            ],
+            "closed": true,
+            "content": "",
+            "tagName": "variable",
+          },
+          "text": "<variable id=\\"rate\\" value=\\"2.5\\"/>",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "%",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "with a loan term of ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.HtmlInline",
+          "tag": Object {
+            "$class": "org.accordproject.commonmark.TagInfo",
+            "attributeString": "id = \\"loanDuration\\" value = \\"15\\" ",
+            "attributes": Array [
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "id",
+                "value": "loanDuration",
+              },
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "value",
+                "value": "15",
+              },
+            ],
+            "closed": true,
+            "content": "",
+            "tagName": "variable",
+          },
+          "text": "<variable id=\\"loanDuration\\" value=\\"15\\"/>",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ",",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "and monthly payments of ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.HtmlInline",
+          "tag": Object {
+            "$class": "org.accordproject.commonmark.TagInfo",
+            "attributeString": "value = \\"667.0\\" ",
+            "attributes": Array [
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "value",
+                "value": "667.0",
+              },
+            ],
+            "closed": true,
+            "content": "",
+            "tagName": "computed",
+          },
+          "text": "<computed value=\\"667.0\\"/>",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.CodeBlock",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "src = \\"foo\\" clauseid = \\"bar\\" ",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "src",
+            "value": "foo",
+          },
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "clauseid",
+            "value": "bar",
+          },
+        ],
+        "closed": false,
+        "content": "
+this is
+multiline
+
+content
+",
+        "tagName": "clause",
+      },
+      "text": "<clause src=\\"foo\\" clauseid=\\"bar\\">
+this is
+multiline
+
+content
+</clause>
+",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts codeblock.md to concerto 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",

--- a/src/__snapshots__/CommonmarkAP.test.js.snap
+++ b/src/__snapshots__/CommonmarkAP.test.js.snap
@@ -32,6 +32,174 @@ Object {
 }
 `;
 
+exports[`markdown converts clause.md to concerto 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "This is a fixed interest loan to the amount of ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.HtmlInline",
+          "tag": Object {
+            "$class": "org.accordproject.commonmark.TagInfo",
+            "attributeString": "id = \\"loanAmount\\" value = \\"100000.0\\" ",
+            "attributes": Array [
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "id",
+                "value": "loanAmount",
+              },
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "value",
+                "value": "100000.0",
+              },
+            ],
+            "closed": true,
+            "content": "",
+            "tagName": "variable",
+          },
+          "text": "<variable id=\\"loanAmount\\" value=\\"100000.0\\"/>",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "at the yearly interest rate of ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.HtmlInline",
+          "tag": Object {
+            "$class": "org.accordproject.commonmark.TagInfo",
+            "attributeString": "id = \\"rate\\" value = \\"2.5\\" ",
+            "attributes": Array [
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "id",
+                "value": "rate",
+              },
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "value",
+                "value": "2.5",
+              },
+            ],
+            "closed": true,
+            "content": "",
+            "tagName": "variable",
+          },
+          "text": "<variable id=\\"rate\\" value=\\"2.5\\"/>",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "%",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "with a loan term of ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.HtmlInline",
+          "tag": Object {
+            "$class": "org.accordproject.commonmark.TagInfo",
+            "attributeString": "id = \\"loanDuration\\" value = \\"15\\" ",
+            "attributes": Array [
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "id",
+                "value": "loanDuration",
+              },
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "value",
+                "value": "15",
+              },
+            ],
+            "closed": true,
+            "content": "",
+            "tagName": "variable",
+          },
+          "text": "<variable id=\\"loanDuration\\" value=\\"15\\"/>",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ",",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "and monthly payments of ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.HtmlInline",
+          "tag": Object {
+            "$class": "org.accordproject.commonmark.TagInfo",
+            "attributeString": "value = \\"667.0\\" ",
+            "attributes": Array [
+              Object {
+                "$class": "org.accordproject.commonmark.Attribute",
+                "name": "value",
+                "value": "667.0",
+              },
+            ],
+            "closed": true,
+            "content": "",
+            "tagName": "computed",
+          },
+          "text": "<computed value=\\"667.0\\"/>",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.CodeBlock",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "src = \\"foo\\" clauseid = \\"bar\\" ",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "src",
+            "value": "foo",
+          },
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "clauseid",
+            "value": "bar",
+          },
+        ],
+        "closed": false,
+        "content": "
+this is
+multiline
+
+content
+",
+        "tagName": "clause",
+      },
+      "text": "<clause src=\\"foo\\" clauseid=\\"bar\\">
+this is
+multiline
+
+content
+</clause>
+",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts codeblock.md to concerto 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",

--- a/test/clause.md
+++ b/test/clause.md
@@ -1,0 +1,13 @@
+This is a fixed interest loan to the amount of <variable id="loanAmount" value="100000.0"/>
+at the yearly interest rate of <variable id="rate" value="2.5"/>%
+with a loan term of <variable id="loanDuration" value="15"/>,
+and monthly payments of <computed value="667.0"/>
+
+```
+<clause src="foo" clauseid="bar">
+this is
+multiline
+
+content
+</clause>
+```


### PR DESCRIPTION
- Separate Cicero extension to markdown in its own model
- Small adjustments to type hierarchy for `Variable` `ComputedVariable` and `Clause`
- Expose Cicero support in `index.js`