### PR TITLE
Clause Nodes fixes

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -38,6 +38,11 @@ require('yargs')
             type: 'boolean',
             default: false
         });
+        yargs.option('--noWrap', {
+            describe: 'do not wrap variables',
+            type: 'boolean',
+            default: false
+        });
     }, (argv) => {
         if (argv.verbose) {
             Logger.info(`parse sample ${argv.sample} markdown`);
@@ -45,7 +50,7 @@ require('yargs')
 
         try {
             argv = Commands.validateParseArgs(argv);
-            return Commands.parse(argv.sample, argv.out, argv.generateMarkdown, argv.withCicero)
+            return Commands.parse(argv.sample, argv.out, argv.generateMarkdown, argv.withCicero, argv.noWrap)
                 .then((result) => {
                     if(result) {Logger.info('\n'+result);}
                 })

--- a/src/CiceroMark.js
+++ b/src/CiceroMark.js
@@ -55,6 +55,7 @@ class CiceroMark {
     fromCommonMark(concertoObject) {
         // Add Cicero nodes
         const parameters = {
+            ciceroMark: this,
             commonMark: this.commonMark,
             modelManager : this.modelManager,
             serializer : this.serializer,
@@ -70,21 +71,32 @@ class CiceroMark {
     /**
      * Converts a ciceromark document back to a regular commmark document
      * @param {*} concertoObject concerto cicero object
+     * @param {object} [options] configuration options
      * @returns {*} concertoObject concerto commonmark
      */
-    toCommonMark(concertoObject) {
+    toCommonMark(concertoObject, options) {
         // Add Cicero nodes
         const parameters = {
             commonMark: this.commonMark,
             modelManager : this.modelManager,
             serializer : this.serializer
         };
-        const visitor = new FromCiceroVisitor();
+        const visitor = new FromCiceroVisitor(options);
         concertoObject.accept( visitor, parameters );
 
         // Validate
         const json = this.serializer.toJSON(concertoObject);
         return this.serializer.fromJSON(json);
+    }
+
+    /**
+     * Converts a ciceromark document back to markdown string
+     * @param {*} concertoObject concerto cicero object
+     * @param {object} [options] configuration options
+     * @returns {*} concertoObject concerto commonmark
+     */
+    toString(concertoObject, options) {
+        return this.commonMark.toString(this.toCommonMark(concertoObject, options));
     }
 
     /**

--- a/src/Commands.js
+++ b/src/Commands.js
@@ -86,9 +86,10 @@ class Commands {
      * @param {string} outPath to an output file
      * @param {boolean} generateMarkdown whether to transform back to markdown
      * @param {boolean} withCicero whether to further transform for Cicero
+     * @param {boolean} noWrap whether to avoid wrapping Cicero variables in XML tags
      * @returns {object} Promise to the result of parsing
      */
-    static parse(samplePath, outPath, generateMarkdown, withCicero) {
+    static parse(samplePath, outPath, generateMarkdown, withCicero, noWrap) {
         const commonMark = new CommonMark();
         const ciceroMark = new CiceroMark();
         const markdownText = Fs.readFileSync(samplePath, 'utf8');
@@ -99,7 +100,8 @@ class Commands {
         let result;
         if (generateMarkdown) {
             if (withCicero) {
-                concertoObject = ciceroMark.toCommonMark(concertoObject);
+                const options = noWrap ? { wrapVariables: false } : null;
+                concertoObject = ciceroMark.toCommonMark(concertoObject, options);
             }
             result = commonMark.toString(concertoObject);
         } else {

--- a/src/CommonMark.js
+++ b/src/CommonMark.js
@@ -72,14 +72,22 @@ class CommonMark {
     }
 
     /**
-     * Is it a HTML-ish node? (html blocks or html inlines but also code blocks)
+     * Is it a HTML node? (html blocks or html inlines)
      * @param {*} json the JS Object for the AST
      * @return {boolean} whether it's a leaf node
      */
     static isHtmlNode(json) {
-        return (json.$class === (COMMON_NS_PREFIX + 'CodeBlock') ||
-                json.$class === (COMMON_NS_PREFIX + 'HtmlInline') ||
+        return (json.$class === (COMMON_NS_PREFIX + 'HtmlInline') ||
                 json.$class === (COMMON_NS_PREFIX + 'HtmlBlock'));
+    }
+
+    /**
+     * Is it a Code Block node?
+     * @param {*} json the JS Object for the AST
+     * @return {boolean} whether it's a leaf node
+     */
+    static isCodeBlockNode(json) {
+        return json.$class === (COMMON_NS_PREFIX + 'CodeBlock');
     }
 
     /**
@@ -107,8 +115,9 @@ class CommonMark {
                 if (CommonMark.isLeafNode(head)) {
                     head.text = t;
                 }
-                if (CommonMark.isHtmlNode(head)) {
-                    const tagInfo = CommonMark.parseHtmlBlock(head.text);
+                if (CommonMark.isHtmlNode(head) || CommonMark.isCodeBlockNode(head)) {
+                    const maybeHtmlText = CommonMark.isHtmlNode(head) ? head.text : head.info;
+                    const tagInfo = CommonMark.parseHtmlBlock(maybeHtmlText);
                     if (tagInfo) {
                         head.tag = {};
                         head.tag.$class = COMMON_NS_PREFIX + 'TagInfo';

--- a/src/CommonMark.js
+++ b/src/CommonMark.js
@@ -258,16 +258,17 @@ class CommonMark {
 
     /**
      * Converts a commonmark document to a markdown string
-     * @param {*} concertoObject concerto commonmark object
+     * @param {*} concertoObject - concerto commonmark object
+     * @param {*} options - options (e.g., wrapVariables)
      * @returns {string} the markdown string
      */
-    toString(concertoObject) {
+    toString(concertoObject, options) {
         const parameters = {};
         parameters.result = '';
         parameters.first = true;
         parameters.indent = 0;
-        const visitor = new ToStringVisitor();
-        concertoObject.accept( visitor, parameters );
+        const visitor = new ToStringVisitor(options);
+        concertoObject.accept(visitor, parameters);
         return parameters.result.trim();
     }
 

--- a/src/FromCiceroVisitor.js
+++ b/src/FromCiceroVisitor.js
@@ -24,6 +24,13 @@ const { COMMON_NS_PREFIX } = require('./Models');
  * markdown content. The resulting AST *should* be equivalent however.
  */
 class FromCiceroVisitor {
+    /**
+     * Construct the visitor
+     * @param {object} [options] configuration options
+     */
+    constructor(options) {
+        this.options = options ? options : { wrapVariables: true };
+    }
 
     /**
      * Visits a sub-tree and return the markdown
@@ -108,7 +115,11 @@ class FromCiceroVisitor {
             // Create the text for that document
             const content = '';
             const attributeString = `id="${thing.id}" value="${thing.value}"`;
-            thing.text = `<variable ${attributeString}/>`;
+            if (this.options && !this.options.wrapVariables) {
+                thing.text = decodeURI(thing.value); // to decode
+            } else {
+                thing.text = `<variable ${attributeString}/>`;
+            }
 
             // Create the proper tag
             let tag = {};
@@ -144,7 +155,11 @@ class FromCiceroVisitor {
             // Create the text for that document
             const content = '';
             const attributeString = `value="${thing.value}"`;
-            thing.text = `<computed ${attributeString}/>`;
+            if (this.options && !this.options.wrapVariables) {
+                thing.text = decodeURI(thing.value); // to decode
+            } else {
+                thing.text = `<computed ${attributeString}/>`;
+            }
 
             // Create the proper tag
             let tag = {};

--- a/src/FromCiceroVisitor.js
+++ b/src/FromCiceroVisitor.js
@@ -50,6 +50,7 @@ class FromCiceroVisitor {
             let jsonSource = {};
             let jsonTarget = {};
 
+            FromCiceroVisitor.visitChildren(this, thing, parameters);
             // Revert to CodeBlock
             jsonTarget.$class = COMMON_NS_PREFIX + 'CodeBlock';
 
@@ -62,7 +63,7 @@ class FromCiceroVisitor {
             const content = parameters.commonMark.toString(parameters.serializer.fromJSON(jsonSource));
             const attributeString = `src="${clauseJson.src}" clauseid="${clauseJson.clauseid}"`;
 
-            jsonTarget.text = `<clause ${attributeString}>\n${content}\n</clause>\n`;
+            jsonTarget.text = content + '\n';
 
             // Create the proper tag
             let tag = {};
@@ -91,11 +92,13 @@ class FromCiceroVisitor {
 
             delete thing.clauseid;
             delete thing.src;
+            delete thing.clauseText;
 
             thing.$classDeclaration = validatedTarget.$classDeclaration;
             thing.tag = validatedTarget.tag;
             thing.nodes = validatedTarget.nodes;
             thing.text = validatedTarget.text;
+            thing.info = `<clause ${attributeString}/>`;
         }
             break;
         case 'Variable': {

--- a/src/Models.js
+++ b/src/Models.js
@@ -133,6 +133,7 @@ import org.accordproject.commonmark.*
 concept Clause extends Child {
     o String clauseid
     o String src
+    o String clauseText
 }
 
 concept Variable extends Child {

--- a/src/ToCiceroVisitor.js
+++ b/src/ToCiceroVisitor.js
@@ -66,10 +66,12 @@ class ToCiceroVisitor {
                     thing.src = tag.attributes[0].value;
                     thing.clauseid = tag.attributes[1].value;
 
-                    thing.nodes = parameters.commonMark.fromString(tag.content).nodes;
+                    thing.nodes = parameters.commonMark.fromString(thing.text).nodes;
                     ToCiceroVisitor.visitNodes(this, thing.nodes, parameters);
+                    thing.clauseText = thing.text;
                     thing.text = null; // Remove text
                     delete thing.tag;
+                    delete thing.info;
                 }
                 else if (tag.attributes[1].name === 'src' &&
                          tag.attributes[0].name === 'clauseid') {
@@ -77,10 +79,12 @@ class ToCiceroVisitor {
                     thing.clauseid = tag.attributes[0].value;
                     thing.src = tag.attributes[1].value;
 
-                    thing.nodes = parameters.commonMark.fromString(tag.content).nodes;
+                    thing.nodes = parameters.commonMark.fromString(thing.text).nodes;
                     ToCiceroVisitor.visitNodes(this, thing.nodes, parameters);
+                    thing.clauseText = thing.text;
                     thing.text = null; // Remove text
                     delete thing.tag;
+                    delete thing.info;
                 } else {
                     //console.log('Found Clause but without \'clauseid\' and \'src\' attributes ');
                 }

--- a/src/ToCiceroVisitor.js
+++ b/src/ToCiceroVisitor.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const { CICERO_NS_PREFIX } = require('./Models');
+const { COMMON_NS_PREFIX, CICERO_NS_PREFIX } = require('./Models');
 
 /**
  * Converts a commonmark model instance to a markdown string.
@@ -68,10 +68,20 @@ class ToCiceroVisitor {
 
                     thing.nodes = parameters.commonMark.fromString(thing.text).nodes;
                     ToCiceroVisitor.visitNodes(this, thing.nodes, parameters);
-                    thing.clauseText = thing.text;
+
                     thing.text = null; // Remove text
+                    thing.clauseText = '';
                     delete thing.tag;
                     delete thing.info;
+
+                    // Go over the loaded clause to generate the unwrapped text
+                    let clone = parameters.serializer.toJSON(thing);
+                    clone.$class = COMMON_NS_PREFIX + 'Paragraph';
+                    delete clone.clauseid;
+                    delete clone.src;
+                    delete clone.clauseText;
+                    clone = parameters.serializer.fromJSON(clone);
+                    thing.clauseText = parameters.ciceroMark.toString(clone, { wrapVariables: false });
                 }
                 else if (tag.attributes[1].name === 'src' &&
                          tag.attributes[0].name === 'clauseid') {
@@ -81,10 +91,19 @@ class ToCiceroVisitor {
 
                     thing.nodes = parameters.commonMark.fromString(thing.text).nodes;
                     ToCiceroVisitor.visitNodes(this, thing.nodes, parameters);
-                    thing.clauseText = thing.text;
                     thing.text = null; // Remove text
+                    thing.clauseText = '';
                     delete thing.tag;
                     delete thing.info;
+
+                    // Go over the loaded clause to generate the unwrapped text
+                    let clone = parameters.serializer.toJSON(thing);
+                    clone.$class = COMMON_NS_PREFIX + 'Paragraph';
+                    delete clone.clauseid;
+                    delete clone.src;
+                    delete clone.clauseText;
+                    clone = parameters.serializer.fromJSON(clone);
+                    thing.clauseText = parameters.ciceroMark.toString(clone, { wrapVariables: false });
                 } else {
                     //console.log('Found Clause but without \'clauseid\' and \'src\' attributes ');
                 }

--- a/src/ToStringVisitor.js
+++ b/src/ToStringVisitor.js
@@ -124,7 +124,7 @@ class ToStringVisitor {
         switch(thing.getType()) {
         case 'CodeBlock':
             ToStringVisitor.newParagraph(parameters);
-            parameters.result += `\`\`\`${thing.info ? thing.info : ''}\n${thing.text}\`\`\`\n\n`;
+            parameters.result += `\`\`\`${thing.info ? ' ' + thing.info : ''}\n${thing.text}\`\`\`\n\n`;
             break;
         case 'Code':
             parameters.result += `\`${thing.text}\``;

--- a/src/ToStringVisitor.js
+++ b/src/ToStringVisitor.js
@@ -22,7 +22,6 @@
  * markdown content. The resulting AST *should* be equivalent however.
  */
 class ToStringVisitor {
-
     /**
      * Visits a sub-tree and return the markdown
      * @param {*} visitor the visitor to use

--- a/src/__snapshots__/CiceroMark.test.js.snap
+++ b/src/__snapshots__/CiceroMark.test.js.snap
@@ -49,22 +49,22 @@ Object {
       "info": "<clause src=\\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\">",
       "tag": Object {
         "$class": "org.accordproject.commonmark.TagInfo",
-        "attributeString": "id = \\"shipper\\" value = \\"%22Party%20A%22\\" ",
+        "attributeString": "src = \\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid = \\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" ",
         "attributes": Array [
           Object {
             "$class": "org.accordproject.commonmark.Attribute",
-            "name": "id",
-            "value": "shipper",
+            "name": "src",
+            "value": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
           },
           Object {
             "$class": "org.accordproject.commonmark.Attribute",
-            "name": "value",
-            "value": "%22Party%20A%22",
+            "name": "clauseid",
+            "value": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
           },
         ],
         "closed": false,
         "content": "",
-        "tagName": "variable",
+        "tagName": "clause",
       },
       "text": "Acceptance of Delivery. <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> will be deemed to have completed its delivery obligations if in <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/>'s opinion, the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> satisfies the Acceptance Criteria, and <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> notifies <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> in writing that it is accepting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
 
@@ -240,7 +240,38 @@ Object {
       ],
     },
     Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "This is a fixed interest loan to the amount of 100000.0",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "at the yearly interest rate of 2.5%",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "with a loan term of 15,",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "and monthly payments of 667.0",
+        },
+      ],
+    },
+    Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
+      "info": "<clause src=\\"foo\\" clauseid=\\"bar\\"/>",
       "tag": Object {
         "$class": "org.accordproject.commonmark.TagInfo",
         "attributeString": "src = \\"foo\\" clauseid = \\"bar\\" ",
@@ -256,21 +287,14 @@ Object {
             "value": "bar",
           },
         ],
-        "closed": false,
-        "content": "
-this is
-multiline
-
-content
-",
+        "closed": true,
+        "content": "",
         "tagName": "clause",
       },
-      "text": "<clause src=\\"foo\\" clauseid=\\"bar\\">
-this is
-multiline
+      "text": "this is
+multiline <variable id=\\"rate\\" value=\\"2.5\\"/>
 
 content
-</clause>
 ",
     },
   ],
@@ -301,6 +325,20 @@ Object {
     Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
       "info": "<video src=\\"https://www.youtube.com/embed/dQw4w9WgXcQ\\"/>",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "src = \\"https://www.youtube.com/embed/dQw4w9WgXcQ\\" ",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "src",
+            "value": "https://www.youtube.com/embed/dQw4w9WgXcQ",
+          },
+        ],
+        "closed": true,
+        "content": "",
+        "tagName": "video",
+      },
       "text": "  this is a multiline
   code
 
@@ -10231,14 +10269,6 @@ Object {
     },
     Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
-      "tag": Object {
-        "$class": "org.accordproject.commonmark.TagInfo",
-        "attributeString": "",
-        "attributes": Array [],
-        "closed": false,
-        "content": "",
-        "tagName": "div",
-      },
       "text": "<div>
 ",
     },
@@ -10500,16 +10530,6 @@ Object {
     },
     Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
-      "tag": Object {
-        "$class": "org.accordproject.commonmark.TagInfo",
-        "attributeString": "",
-        "attributes": Array [],
-        "closed": false,
-        "content": "
-  Hi
-",
-        "tagName": "td",
-      },
       "text": "<td>
   Hi
 </td>
@@ -11702,14 +11722,6 @@ Object {
   "nodes": Array [
     Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
-      "tag": Object {
-        "$class": "org.accordproject.commonmark.TagInfo",
-        "attributeString": "",
-        "attributes": Array [],
-        "closed": false,
-        "content": "",
-        "tagName": "a",
-      },
       "text": "<a/>
 *hi*
 

--- a/src/__snapshots__/CommonMark.test.js.snap
+++ b/src/__snapshots__/CommonMark.test.js.snap
@@ -49,22 +49,22 @@ Object {
       "info": "<clause src=\\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\">",
       "tag": Object {
         "$class": "org.accordproject.commonmark.TagInfo",
-        "attributeString": "id = \\"shipper\\" value = \\"%22Party%20A%22\\" ",
+        "attributeString": "src = \\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid = \\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" ",
         "attributes": Array [
           Object {
             "$class": "org.accordproject.commonmark.Attribute",
-            "name": "id",
-            "value": "shipper",
+            "name": "src",
+            "value": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
           },
           Object {
             "$class": "org.accordproject.commonmark.Attribute",
-            "name": "value",
-            "value": "%22Party%20A%22",
+            "name": "clauseid",
+            "value": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
           },
         ],
         "closed": false,
         "content": "",
-        "tagName": "variable",
+        "tagName": "clause",
       },
       "text": "Acceptance of Delivery. <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> will be deemed to have completed its delivery obligations if in <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/>'s opinion, the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> satisfies the Acceptance Criteria, and <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> notifies <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> in writing that it is accepting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
 
@@ -240,7 +240,38 @@ Object {
       ],
     },
     Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "This is a fixed interest loan to the amount of 100000.0",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "at the yearly interest rate of 2.5%",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "with a loan term of 15,",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "and monthly payments of 667.0",
+        },
+      ],
+    },
+    Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
+      "info": "<clause src=\\"foo\\" clauseid=\\"bar\\"/>",
       "tag": Object {
         "$class": "org.accordproject.commonmark.TagInfo",
         "attributeString": "src = \\"foo\\" clauseid = \\"bar\\" ",
@@ -256,21 +287,14 @@ Object {
             "value": "bar",
           },
         ],
-        "closed": false,
-        "content": "
-this is
-multiline
-
-content
-",
+        "closed": true,
+        "content": "",
         "tagName": "clause",
       },
-      "text": "<clause src=\\"foo\\" clauseid=\\"bar\\">
-this is
-multiline
+      "text": "this is
+multiline <variable id=\\"rate\\" value=\\"2.5\\"/>
 
 content
-</clause>
 ",
     },
   ],
@@ -301,6 +325,20 @@ Object {
     Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
       "info": "<video src=\\"https://www.youtube.com/embed/dQw4w9WgXcQ\\"/>",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "src = \\"https://www.youtube.com/embed/dQw4w9WgXcQ\\" ",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "src",
+            "value": "https://www.youtube.com/embed/dQw4w9WgXcQ",
+          },
+        ],
+        "closed": true,
+        "content": "",
+        "tagName": "video",
+      },
       "text": "  this is a multiline
   code
 

--- a/test/clause.md
+++ b/test/clause.md
@@ -3,11 +3,15 @@ at the yearly interest rate of <variable id="rate" value="2.5"/>%
 with a loan term of <variable id="loanDuration" value="15"/>,
 and monthly payments of <computed value="667.0"/>
 
-```
-<clause src="foo" clauseid="bar">
+
+This is a fixed interest loan to the amount of 100000.0
+at the yearly interest rate of 2.5%
+with a loan term of 15,
+and monthly payments of 667.0
+
+``` <clause src="foo" clauseid="bar"/>
 this is
-multiline
+multiline <variable id="rate" value="2.5"/>
 
 content
-</clause>
 ```


### PR DESCRIPTION
- Clauses are now recognised through the info part of the code block
- Bug fixes to clauses containing variables
- Add convenience calculation for clause text without variables tags
