### PR TITLE
Bug Fixes

### DIFF
--- a/packages/markdown-common/src/ToMarkdownStringVisitor.js
+++ b/packages/markdown-common/src/ToMarkdownStringVisitor.js
@@ -200,14 +200,7 @@ class ToStringVisitor {
         }
             break;
         case 'Item':
-            if(parameters.type === 'ordered') {
-                parameters.result += '\n${ToStringVisitor.mkIndent(parameters)}$1. ';
-            }
-            else {
-                parameters.result += '\n${ToStringVisitor.mkIndent(parameters)}- ';
-            }
-            parameters.result += ToStringVisitor.visitChildren(this, thing);
-            break;
+            throw new Error('Item node should not occur outside of List nodes');
         case 'Document':
             parameters.result += ToStringVisitor.visitChildren(this, thing);
             break;

--- a/packages/markdown-slate/src/Slate.test.js
+++ b/packages/markdown-slate/src/Slate.test.js
@@ -18,7 +18,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const Value = require('slate').Value;
 const CommonMark = require('@accordproject/markdown-common').CommonMark;
 const SlateMark = require('./SlateMark');
 
@@ -53,9 +52,7 @@ describe('slate', () => {
     getSlateFiles().forEach( ([file, jsonText], index) => {
         it(`converts ${file} to concerto`, () => {
             const slateDom = JSON.parse(jsonText);
-            const value = Value.fromJSON(slateDom);
-            const json = slateMark.toCommonMark(value.document);
-            console.log('From slate', JSON.stringify(json, null, 4));
+            const json = slateMark.toCommonMark(slateDom);
 
             // check no changes to the concerto
             expect(json).toMatchSnapshot();

--- a/packages/markdown-slate/src/SlateMark.js
+++ b/packages/markdown-slate/src/SlateMark.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const Value = require('slate').Value;
 const ToSlateVisitor = require('./ToSlateVisitor');
 const slateToCommonMarkAst = require('./slateToCommonMarkAst');
 
@@ -77,7 +78,8 @@ class SlateMark {
      * @returns {*} the common mark AST
      */
     toCommonMark(json) {
-        return this.serializer.toJSON(slateToCommonMarkAst(json));
+        const value = Value.fromJSON(json);
+        return this.serializer.toJSON(slateToCommonMarkAst(value.document));
     }
 }
 


### PR DESCRIPTION
- Slate roundtrip on CodeBlocks now works from command line
- Encapsulate Value.fromJSON call from Slate
- Standalone item nodes now raise an error
