### PR TITLE
feature(list) add option to not index lists when generating markdown

### DIFF
--- a/packages/markdown-cli/index.js
+++ b/packages/markdown-cli/index.js
@@ -48,6 +48,11 @@ require('yargs')
             type: 'boolean',
             default: false
         });
+        yargs.option('noIndex', {
+            describe: 'do not index ordered lists',
+            type: 'boolean',
+            default: false
+        });
     }, (argv) => {
         if (argv.verbose) {
             Logger.info(`parse sample ${argv.sample} markdown`);
@@ -60,6 +65,7 @@ require('yargs')
             options.cicero = argv.cicero;
             options.slate = argv.slate;
             options.noWrap = argv.noWrap;
+            options.noIndex = argv.noIndex;
             return Commands.parse(argv.sample, argv.out, options)
                 .then((result) => {
                     if(result) {Logger.info('\n'+result);}

--- a/packages/markdown-cli/lib/Commands.js
+++ b/packages/markdown-cli/lib/Commands.js
@@ -90,11 +90,16 @@ class Commands {
      * @param {boolean} [options.cicero] whether to further transform for Cicero
      * @param {boolean} [options.slate] whether to further transform for Slate
      * @param {boolean} [options.noWrap] whether to avoid wrapping Cicero variables in XML tags
+     * @param {boolean} [options.noIndex] do not index ordered list (i.e., use 1. everywhere)
      * @returns {object} Promise to the result of parsing
      */
     static parse(samplePath, outPath, options) {
-        const { roundtrip, cicero, slate, noWrap } = options;
-        const commonMark = new CommonMark({ tagInfo: true });
+        const { roundtrip, cicero, slate, noWrap, noIndex } = options;
+        const commonOptions = {};
+        commonOptions.tagInfo = true;
+        commonOptions.noIndex = noIndex ? true : false;
+        
+        const commonMark = new CommonMark(commonOptions);
         const ciceroMark = new CiceroMark();
         const slateMark = new SlateMark();
 
@@ -108,8 +113,9 @@ class Commands {
         }
         if (roundtrip) {
             if (cicero) {
-                const options = noWrap ? { wrapVariables: false } : null;
-                result = ciceroMark.toCommonMark(result, options);
+                const ciceroOptions = {};
+                ciceroOptions.wrapVariables = noWrap ? false : true;
+                result = ciceroMark.toCommonMark(result, ciceroOptions);
             } else if (slate) {
                 result = slateMark.toCommonMark(result);
                 //console.log('AFTER COMMONMARK ' + JSON.stringify(result));

--- a/packages/markdown-common/src/CommonMark.js
+++ b/packages/markdown-common/src/CommonMark.js
@@ -38,6 +38,7 @@ class CommonMark {
      * @param {boolean} [options.trimText] trims all text nodes
      * @param {boolean} [options.disableValidation] returns unvalidated JSON, rather than a Concerto model
      * @param {boolean} [options.enableSourceLocation] if true then location information is returned
+     * @param {boolean} [options.noIndex] do not index ordered list (i.e., use 1. everywhere)
      * @param {boolean} [options.tagInfo] Construct tags for HTML elements
      */
     constructor(options) {
@@ -258,15 +259,14 @@ class CommonMark {
     /**
      * Converts a commonmark document to a markdown string
      * @param {*} concertoObject - concerto commonmark object
-     * @param {*} options - options (e.g., wrapVariables)
      * @returns {string} the markdown string
      */
-    toMarkdownStringConcerto(concertoObject, options) {
+    toMarkdownStringConcerto(concertoObject) {
         const parameters = {};
         parameters.result = '';
         parameters.first = true;
         parameters.indent = 0;
-        const visitor = new ToMarkdownStringVisitor(options);
+        const visitor = new ToMarkdownStringVisitor(this.options);
         concertoObject.accept(visitor, parameters);
         return parameters.result.trim();
     }


### PR DESCRIPTION
This is useful when using markdown transform to for Cicero parsing.

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

