### PR TITLE
Small fixes for release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,9 @@ The Slate DOM is defined by the [Slate](https://www.slatejs.org) HTML content-ed
 
 In the project directory, you can run:
 
-#### `npm run build:watch`
-
-Runs the app in the development mode.<br>
-
-Babel will recompile every change as it runs in _watch_ mode.
-
 #### `npm run build`
 
-Similar to `build:watch` but it's a one off build.
+Invokes _lerna_ to build all the `markdown-*` packages.
 
 #### `npm run test`
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "private": true,
   "scripts": {
     "webpack": "webpack --config webpack.config.js --mode production",
-    "build": "babel src -d lib --copy-files",
-    "build:watch": "babel src -d lib --copy-files --watch",
+    "build": "lerna run build",
     "publish": "./scripts/manualrelease.sh",
     "pretest": "npm run licchk",
     "test": "lerna run test",

--- a/packages/markdown-cli/README.md
+++ b/packages/markdown-cli/README.md
@@ -11,7 +11,7 @@ npm install @accordproject/markdown-cli --save
 ## Usage
 
 ```
-mdtransform parse --help
+markus parse --help
 
 parse sample markdown to Concerto instance
 

--- a/packages/markdown-cli/package.json
+++ b/packages/markdown-cli/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "bin": {
-    "mdtransform": "./index.js"
+    "markus": "./index.js"
   },
   "files": [
     "bin",

--- a/packages/markdown-cli/test/data/acceptance.json
+++ b/packages/markdown-cli/test/data/acceptance.json
@@ -37,7 +37,6 @@
        {
           "$class":"org.accordproject.commonmark.CodeBlock",
           "info":"<clause src=\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\" clauseid=\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\"/>",
-          "text":"Acceptance of Delivery. <variable id=\"shipper\" value=\"%22Party%20A%22\"/> will be deemed to have completed its delivery obligations if in <variable id=\"receiver\" value=\"%22Party%20B%22\"/>'s opinion, the <variable id=\"deliverable\" value=\"%22Widgets%22\"/> satisfies the Acceptance Criteria, and <variable id=\"receiver\" value=\"%22Party%20B%22\"/> notifies <variable id=\"shipper\" value=\"%22Party%20A%22\"/> in writing that it is accepting the <variable id=\"deliverable\" value=\"%22Widgets%22\"/>.\n\nInspection and Notice. <variable id=\"receiver\" value=\"%22Party%20B%22\"/> will have <variable id=\"businessDays\" value=\"10\"/> Business Days' to inspect and evaluate the <variable id=\"deliverable\" value=\"%22Widgets%22\"/> on the delivery date before notifying <variable id=\"shipper\" value=\"%22Party%20A%22\"/> that it is either accepting or rejecting the <variable id=\"deliverable\" value=\"%22Widgets%22\"/>.\n\nAcceptance Criteria. The \"Acceptance Criteria\" are the specifications the <variable id=\"deliverable\" value=\"%22Widgets%22\"/> must meet for the <variable id=\"shipper\" value=\"%22Party%20A%22\"/> to comply with its requirements and obligations under this agreement, detailed in <variable id=\"attachment\" value=\"%22Attachment%20X%22\"/>, attached to this agreement.\n",
           "tag":{
              "$class":"org.accordproject.commonmark.TagInfo",
              "tagName":"clause",
@@ -56,7 +55,8 @@
              ],
              "content":"",
              "closed":true
-          }
+          },
+          "text":"Acceptance of Delivery. <variable id=\"shipper\" value=\"%22Party%20A%22\"/> will be deemed to have completed its delivery obligations if in <variable id=\"receiver\" value=\"%22Party%20B%22\"/>'s opinion, the <variable id=\"deliverable\" value=\"%22Widgets%22\"/> satisfies the Acceptance Criteria, and <variable id=\"receiver\" value=\"%22Party%20B%22\"/> notifies <variable id=\"shipper\" value=\"%22Party%20A%22\"/> in writing that it is accepting the <variable id=\"deliverable\" value=\"%22Widgets%22\"/>.\n\nInspection and Notice. <variable id=\"receiver\" value=\"%22Party%20B%22\"/> will have <variable id=\"businessDays\" value=\"10\"/> Business Days' to inspect and evaluate the <variable id=\"deliverable\" value=\"%22Widgets%22\"/> on the delivery date before notifying <variable id=\"shipper\" value=\"%22Party%20A%22\"/> that it is either accepting or rejecting the <variable id=\"deliverable\" value=\"%22Widgets%22\"/>.\n\nAcceptance Criteria. The \"Acceptance Criteria\" are the specifications the <variable id=\"deliverable\" value=\"%22Widgets%22\"/> must meet for the <variable id=\"shipper\" value=\"%22Party%20A%22\"/> to comply with its requirements and obligations under this agreement, detailed in <variable id=\"attachment\" value=\"%22Attachment%20X%22\"/>, attached to this agreement.\n"
        }
     ]
  }

--- a/packages/markdown-common/src/CommonMarkTransformer.js
+++ b/packages/markdown-common/src/CommonMarkTransformer.js
@@ -200,7 +200,8 @@ class CommonMarkTransformer {
             return this.serializer.fromJSON(json);
         }
         else {
-            return json;
+            const validJson = this.serializer.fromJSON(json);
+            return this.serializer.toJSON(validJson);
         }
     }
 


### PR DESCRIPTION
- Names CLI `markus`
- Validates when converting from markdown to CommonMarkDOM even when format is `json`
- Small fixes to README and build commands
