### PR TITLE
Various fixes to CLI and new lines in transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A transformation framework for converting markdown content to HTML, Slate (for rich-text editing) and others DOMs.
 
-![Architecture Diagram](http://www.plantuml.com/plantuml/png/bP0nJyCm48Lt_ugdxabsX50b61Ye6CfMTR3iQ-BMiIFxeXGX_ZkDMvgeBWEROx_Sk-zRHfQ1-zOAqKbra3LXqSfmq7vmXR9cWIy1R3eP8ct5zzsKRrllBi7LvHPh3iRLMpmMVLSyOVESKkCpNjvNQPJpJ0YcRXX-boU0XhcB3rNLUaqsbb8f7tGN_9uKbpxKrRbwtAJwNQTi-0H3JcCSVrEIxoU0wrKVAO8Rma3M5ffsnf4MmDGobYAv291E8tuwbiUfxPuTeoZuP2T3dEIaq1nzy_gnUfj9p3APm2dn7u7fboHmEjugpA6YbKo9wTgQCQt7p5-hpXw1yuU9a0u9EnZL54n71cd3Fin8Xc4eK_i-ZW2pBSNoTEvR-mC0)
+![Architecture Diagram](http://www.plantuml.com/plantuml/png/bP6zJiCm58NtFCLHzoGxGgWI30nK36MhEbZnJUBMFv5zenGXtXtPDQGYfH9ROf_Syzqlwy32ysXqCOZcA3h2oWX_b6woPQFL2Xy5i1k43xGlFejhAMUCipcuoQVOibUss-E-78Vo0Rl7b8hNU7hTf57MCS6hhcUuTfa0UkOXtDMrSP9qg4JJE2y7xmxKSELyLv-h8qdzZLFrR7H1LYAENvJyvYk0dwFMUIEOIOBfn1W31N1FA829j2ubjSgInDmQ8P3S-9WILYAyMnQd6U2QCDMGTqdOOklPLmejVMbgiwuS-8-kz4dIDJzcOJTuWnPC6JUtBd2tCNETzF8EEB-e067n_BPvWLTDNoRX91KxVx78D4rLAZ-4o7yJCcxn1sD6Z6tvjqV8DLav6lq5)
 
 > Note: you can regenerate this diagram by visiting http://www.plantuml.com/plantuml/uml/ and pasting the contents of `architecture.puml` from this repository.
 

--- a/architecture.puml
+++ b/architecture.puml
@@ -1,5 +1,4 @@
 @startuml
-
 package "markdown-cli" {
   [parse]
 }
@@ -22,11 +21,7 @@ package "markdown-cicero" {
   [CommonMark DOM] <-up-> [CiceroMark DOM]
 }
 
-package "markdown-html" {
-  [CiceroMark DOM] -> [HTML String]
-}
-
-note right of [CiceroMark DOM]
+note left of [CiceroMark DOM]
   https://models.accordproject.org/ciceromark/ciceromark.html
 end note
 
@@ -34,10 +29,12 @@ package "markdown-slate" {
   [CiceroMark DOM] <-up-> [Slate DOM]
 }
 
-note right of [Slate DOM]
+note left of [Slate DOM]
   Slate is an HTML rich-text editor
   https://www.slatejs.org
 end note
 
-
+package "markdown-html" {
+  [CiceroMark DOM] -up-> [HTML String]
+}
 @enduml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "markdown-transform",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1312,6 +1312,34 @@
 				"dedent": "^0.7.0",
 				"npmlog": "^4.1.2",
 				"yargs": "^12.0.1"
+			},
+			"dependencies": {
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"dev": true
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				}
 			}
 		},
 		"@lerna/collect-uncommitted": {
@@ -4689,6 +4717,12 @@
 						"pify": "^3.0.0"
 					}
 				},
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"dev": true
+				},
 				"supports-color": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -4696,6 +4730,26 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^2.0.0"
+					}
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
 					}
 				}
 			}
@@ -18202,28 +18256,79 @@
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yargs": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-			"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+			"version": "13.2.4",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+			"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.2.0",
+				"cliui": "^5.0.0",
 				"find-up": "^3.0.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"os-locale": "^3.1.0",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
+				"require-main-filename": "^2.0.0",
 				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
+				"string-width": "^3.0.0",
 				"which-module": "^2.0.0",
-				"y18n": "^3.2.1 || ^4.0.0",
-				"yargs-parser": "^11.1.1"
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.1.0"
 			},
 			"dependencies": {
-				"require-main-filename": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
 				}
 			}
 		},
@@ -18244,6 +18349,32 @@
 				"flat": "^4.1.0",
 				"lodash": "^4.17.11",
 				"yargs": "^12.0.5"
+			},
+			"dependencies": {
+				"require-main-filename": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				}
 			}
 		},
 		"zip-stream": {

--- a/packages/markdown-cli/index.js
+++ b/packages/markdown-cli/index.js
@@ -19,7 +19,9 @@ const Logger = require('@accordproject/markdown-common').Logger;
 const Commands = require('./lib/Commands');
 
 require('yargs')
-    .command('parse', 'parse sample markdown to Concerto instance', (yargs) => {
+    .scriptName('markus')
+    .usage('$0 <cmd> [args]')
+    .command('parse', 'parse and transform sample markdown', (yargs) => {
         yargs.option('sample', {
             describe: 'path to the clause text',
             type: 'string'
@@ -40,6 +42,11 @@ require('yargs')
         });
         yargs.option('slate', {
             describe: 'further transform to Slate DOM',
+            type: 'boolean',
+            default: false
+        });
+        yargs.option('html', {
+            describe: 'further transform to HTML',
             type: 'boolean',
             default: false
         });
@@ -64,6 +71,7 @@ require('yargs')
             options.roundtrip = argv.roundtrip;
             options.cicero = argv.cicero;
             options.slate = argv.slate;
+            options.html = argv.html;
             options.noWrap = argv.noWrap;
             options.noIndex = argv.noIndex;
             return Commands.parse(argv.sample, argv.out, options)
@@ -82,4 +90,5 @@ require('yargs')
         alias: 'v',
         default: false
     })
+    .help()
     .parse();

--- a/packages/markdown-cli/package.json
+++ b/packages/markdown-cli/package.json
@@ -49,12 +49,14 @@
     "license-check": "1.1.5",
     "mocha": "6.1.4",
     "nyc": "14.1.1",
-    "tsd-jsdoc": "^2.3.0"
+    "tsd-jsdoc": "^2.3.0",
+    "yargs": "13.2.4"
   },
   "dependencies": {
     "@accordproject/markdown-common": "0.4.0",
     "@accordproject/markdown-cicero": "0.4.0",
     "@accordproject/markdown-slate": "0.4.0",
+    "@accordproject/markdown-html": "0.4.0",
     "jsome": "2.5.0",
     "winston": "3.2.1"
   },

--- a/packages/markdown-common/src/ToMarkdownStringVisitor.js
+++ b/packages/markdown-common/src/ToMarkdownStringVisitor.js
@@ -118,11 +118,11 @@ class ToMarkdownStringVisitor {
     /**
      * Prints a new paragraph if not first
      * @param {*} parameters - the current parameters
+     * @param {*} level - number of new lines
      */
-    static newParagraph(parameters) {
-        if (!parameters.first) {
-            parameters.result += '\n\n';
-        }
+    static newBlock(parameters,level) {
+        const newlines = parameters.first ? '' : Array(level).fill('\n').join('');
+        parameters.result += newlines;
     }
 
     /**
@@ -134,7 +134,7 @@ class ToMarkdownStringVisitor {
 
         switch(thing.getType()) {
         case 'CodeBlock':
-            ToMarkdownStringVisitor.newParagraph(parameters);
+            ToMarkdownStringVisitor.newBlock(parameters,2);
             parameters.result += `\`\`\`${thing.info ? ' ' + thing.info : ''}\n${thing.text}\`\`\`\n\n`;
             break;
         case 'Code':
@@ -151,11 +151,12 @@ class ToMarkdownStringVisitor {
             break;
         case 'BlockQuote': {
             const parametersIn = ToMarkdownStringVisitor.mkParametersIn(parameters);
-            ToMarkdownStringVisitor.newParagraph(parameters);
+            ToMarkdownStringVisitor.newBlock(parameters,2);
             parameters.result += `> ${ToMarkdownStringVisitor.visitChildren(this, thing, parametersIn)}`;
         }
             break;
         case 'Heading': {
+            ToMarkdownStringVisitor.newBlock(parameters,2);
             const level = parseInt(thing.level);
             if (level < 3) {
                 parameters.result += `${ToMarkdownStringVisitor.visitChildren(this, thing)}\n${ToMarkdownStringVisitor.mkSetextHeading(level)}`;
@@ -165,7 +166,7 @@ class ToMarkdownStringVisitor {
         }
             break;
         case 'ThematicBreak':
-            ToMarkdownStringVisitor.newParagraph(parameters);
+            ToMarkdownStringVisitor.newBlock(parameters,2);
             parameters.result += '---\n';
             break;
         case 'Linebreak':
@@ -181,11 +182,11 @@ class ToMarkdownStringVisitor {
             parameters.result += `![${ToMarkdownStringVisitor.visitChildren(this, thing)}](${thing.destination})`;
             break;
         case 'Paragraph':
-            ToMarkdownStringVisitor.newParagraph(parameters);
+            ToMarkdownStringVisitor.newBlock(parameters,2);
             parameters.result += `${ToMarkdownStringVisitor.visitChildren(this, thing)}`;
             break;
         case 'HtmlBlock':
-            ToMarkdownStringVisitor.newParagraph(parameters);
+            ToMarkdownStringVisitor.newBlock(parameters,2);
             parameters.result += `${thing.text}`;
             break;
         case 'Text':

--- a/packages/markdown-common/src/__snapshots__/CommonMarkTransformer.test.js.snap
+++ b/packages/markdown-common/src/__snapshots__/CommonMarkTransformer.test.js.snap
@@ -352,6 +352,319 @@ Object {
 }
 `;
 
+exports[`markdown converts editor.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Heading One",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "This is text. This is ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Emph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "italic",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": " text. This is ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "bold",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": " text. This is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Link",
+          "destination": "https://clause.io",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "link",
+            },
+          ],
+          "title": "",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ". This is ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Code",
+          "text": "inline code",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "This is ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Emph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Strong",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "bold and italic",
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": " text",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.BlockQuote",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is a quote.",
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "2",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Heading Two",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "This is more text.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Ordered lists:",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.List",
+      "delimiter": "period",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Item",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "one",
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Item",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "two",
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Item",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "three",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      "start": "1",
+      "tight": "true",
+      "type": "ordered",
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Or:",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.List",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Item",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "apples",
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Item",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "pears",
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Item",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "peaches",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      "tight": "true",
+      "type": "bullet",
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "3",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Sub heading",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Video:",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.HtmlBlock",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "",
+        "attributes": Array [],
+        "closed": true,
+        "content": "",
+        "tagName": "video",
+      },
+      "text": "<video/>",
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Another video:",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.HtmlBlock",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "src = \\"https://www.youtube.com/embed/cmmq-JBMbbQ\\" ",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "src",
+            "value": "https://www.youtube.com/embed/cmmq-JBMbbQ",
+          },
+        ],
+        "closed": true,
+        "content": "",
+        "tagName": "video",
+      },
+      "text": "<video src=\\"https://www.youtube.com/embed/cmmq-JBMbbQ\\"/>",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts emph.md to concerto JSON 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",

--- a/packages/markdown-common/test/data/editor.md
+++ b/packages/markdown-common/test/data/editor.md
@@ -1,0 +1,30 @@
+# Heading One
+This is text. This is *italic* text. This is **bold** text. This is a [link](https://clause.io). This is `inline code`.
+
+This is ***bold and italic*** text
+
+> This is a quote.
+## Heading Two
+This is more text.
+
+Ordered lists:
+
+1. one
+1. two
+1. three
+
+Or:
+
+* apples
+* pears
+* peaches
+
+### Sub heading
+
+Video:
+
+<video/>
+
+Another video:
+
+<video src="https://www.youtube.com/embed/cmmq-JBMbbQ"/>


### PR DESCRIPTION
# Issue #45 

- Fixes transition to headings missing new lines
- Adds HTML to command line
- Add missing `yargs` dependency to `markdown-cli`
- Fixes help message with `markus` name
- Update architecture diagram
