### PR TITLE
fix(slate): move text value from data to nodes

### DIFF
--- a/packages/markdown-cli/test/data/acceptance-slate.json
+++ b/packages/markdown-cli/test/data/acceptance-slate.json
@@ -85,12 +85,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"shipper",
-                           "value":"%22Party%20A%22"
+                           "id":"shipper"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Party%20A%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -103,12 +103,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"receiver",
-                           "value":"%22Party%20B%22"
+                           "id":"receiver"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Party%20B%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -128,12 +128,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"deliverable",
-                           "value":"%22Widgets%22"
+                           "id":"deliverable"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Widgets%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -146,12 +146,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"receiver",
-                           "value":"%22Party%20B%22"
+                           "id":"receiver"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Party%20B%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -164,12 +164,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"shipper",
-                           "value":"%22Party%20A%22"
+                           "id":"shipper"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Party%20A%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -182,12 +182,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"deliverable",
-                           "value":"%22Widgets%22"
+                           "id":"deliverable"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Widgets%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -216,12 +216,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"receiver",
-                           "value":"%22Party%20B%22"
+                           "id":"receiver"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Party%20B%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -234,12 +234,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"businessDays",
-                           "value":"10"
+                           "id":"businessDays"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"10"
+                        }]
                      },
                      {
                         "object":"text",
@@ -266,12 +266,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"deliverable",
-                           "value":"%22Widgets%22"
+                           "id":"deliverable"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Widgets%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -284,12 +284,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"shipper",
-                           "value":"%22Party%20A%22"
+                           "id":"shipper"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Party%20A%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -302,12 +302,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"deliverable",
-                           "value":"%22Widgets%22"
+                           "id":"deliverable"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Widgets%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -364,12 +364,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"deliverable",
-                           "value":"%22Widgets%22"
+                           "id":"deliverable"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Widgets%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -382,12 +382,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"shipper",
-                           "value":"%22Party%20A%22"
+                           "id":"shipper"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Party%20A%22"
+                        }]
                      },
                      {
                         "object":"text",
@@ -400,12 +400,12 @@
                         "object":"inline",
                         "type":"variable",
                         "data":{
-                           "id":"attachment",
-                           "value":"%22Attachment%20X%22"
+                           "id":"attachment"
                         },
-                        "nodes":[
-
-                        ]
+                        "nodes":[{
+                           "object":"text",
+                           "text":"%22Attachment%20X%22"
+                        }]
                      },
                      {
                         "object":"text",

--- a/packages/markdown-slate/src/SlateTransformer.test.js
+++ b/packages/markdown-slate/src/SlateTransformer.test.js
@@ -102,10 +102,13 @@ describe('slate', () => {
                                     'object': 'inline',
                                     'type': 'variable',
                                     'data': {
-                                        'id': 'foo',
-                                        'value': 'bar'
+                                        'id': 'foo'
                                     },
-                                    'nodes': []
+                                    'nodes': [{
+                                        'marks': [],
+                                        'object': 'text',
+                                        'text': 'bar'
+                                    }]
                                 }
                             ]
                         }
@@ -138,10 +141,12 @@ describe('slate', () => {
                                 {
                                     'object': 'inline',
                                     'type': 'computed',
-                                    'data': {
-                                        'value': 'bar'
-                                    },
-                                    'nodes': []
+                                    'data': {},
+                                    'nodes': [{
+                                        'marks': [],
+                                        'object': 'text',
+                                        'text': 'bar'
+                                    }]
                                 }
                             ]
                         }

--- a/packages/markdown-slate/src/ToSlateVisitor.js
+++ b/packages/markdown-slate/src/ToSlateVisitor.js
@@ -153,19 +153,22 @@ class ToSlateVisitor {
                 type: 'variable',
                 data: {
                     id: thing.id,
-                    value: thing.value
                 },
-                nodes: [],
+                nodes: [{
+                    object: 'text',
+                    text: thing.value,
+                }],
             };
             break;
         case 'ComputedVariable':
             result = {
                 object: 'inline',
                 type: 'computed',
-                data: {
-                    value: thing.value
-                },
-                nodes: [],
+                data: {},
+                nodes: [{
+                    object: 'text',
+                    text: thing.value,
+                }],
             };
             break;
         case 'CodeBlock':

--- a/packages/markdown-slate/src/__snapshots__/SlateTransformer.test.js.snap
+++ b/packages/markdown-slate/src/__snapshots__/SlateTransformer.test.js.snap
@@ -42,8 +42,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "shipper",
-              "nodes": Array [],
-              "value": "%22Party%20A%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20A%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -52,8 +57,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "receiver",
-              "nodes": Array [],
-              "value": "%22Party%20B%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20B%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -66,8 +76,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -76,8 +91,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "receiver",
-              "nodes": Array [],
-              "value": "%22Party%20B%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20B%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -86,8 +106,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "shipper",
-              "nodes": Array [],
-              "value": "%22Party%20A%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20A%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -96,8 +121,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -115,8 +145,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "receiver",
-              "nodes": Array [],
-              "value": "%22Party%20B%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20B%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -125,8 +160,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "businessDays",
-              "nodes": Array [],
-              "value": "10",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "10",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -143,8 +183,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -153,8 +198,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "shipper",
-              "nodes": Array [],
-              "value": "%22Party%20A%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20A%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -163,8 +213,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -198,8 +253,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -208,8 +268,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "shipper",
-              "nodes": Array [],
-              "value": "%22Party%20A%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20A%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -218,8 +283,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "attachment",
-              "nodes": Array [],
-              "value": "%22Attachment%20X%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Attachment%20X%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -300,9 +370,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "shipper",
-                  "value": "%22Party%20A%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Party%20A%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -314,9 +389,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "receiver",
-                  "value": "%22Party%20B%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Party%20B%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -333,9 +413,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "deliverable",
-                  "value": "%22Widgets%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Widgets%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -347,9 +432,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "receiver",
-                  "value": "%22Party%20B%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Party%20B%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -361,9 +451,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "shipper",
-                  "value": "%22Party%20A%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Party%20A%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -375,9 +470,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "deliverable",
-                  "value": "%22Widgets%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Widgets%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -401,9 +501,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "receiver",
-                  "value": "%22Party%20B%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Party%20B%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -415,9 +520,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "businessDays",
-                  "value": "10",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "10",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -439,9 +549,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "deliverable",
-                  "value": "%22Widgets%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Widgets%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -453,9 +568,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "shipper",
-                  "value": "%22Party%20A%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Party%20A%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -467,9 +587,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "deliverable",
-                  "value": "%22Widgets%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Widgets%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -513,9 +638,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "deliverable",
-                  "value": "%22Widgets%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Widgets%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -527,9 +657,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "shipper",
-                  "value": "%22Party%20A%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Party%20A%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -541,9 +676,14 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
               Object {
                 "data": Object {
                   "id": "attachment",
-                  "value": "%22Attachment%20X%22",
                 },
-                "nodes": Array [],
+                "nodes": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "text",
+                    "text": "%22Attachment%20X%22",
+                  },
+                ],
                 "object": "inline",
                 "type": "variable",
               },
@@ -609,8 +749,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "shipper",
-              "nodes": Array [],
-              "value": "%22Party%20A%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20A%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -619,8 +764,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "receiver",
-              "nodes": Array [],
-              "value": "%22Party%20B%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20B%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -633,8 +783,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -643,8 +798,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "receiver",
-              "nodes": Array [],
-              "value": "%22Party%20B%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20B%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -653,8 +813,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "shipper",
-              "nodes": Array [],
-              "value": "%22Party%20A%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20A%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -663,8 +828,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -682,8 +852,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "receiver",
-              "nodes": Array [],
-              "value": "%22Party%20B%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20B%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -692,8 +867,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "businessDays",
-              "nodes": Array [],
-              "value": "10",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "10",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -710,8 +890,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -720,8 +905,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "shipper",
-              "nodes": Array [],
-              "value": "%22Party%20A%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20A%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -730,8 +920,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -765,8 +960,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "deliverable",
-              "nodes": Array [],
-              "value": "%22Widgets%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Widgets%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -775,8 +975,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "shipper",
-              "nodes": Array [],
-              "value": "%22Party%20A%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Party%20A%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",
@@ -785,8 +990,13 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "attachment",
-              "nodes": Array [],
-              "value": "%22Attachment%20X%22",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "%22Attachment%20X%22",
+                },
+              ],
+              "value": undefined,
             },
             Object {
               "$class": "org.accordproject.commonmark.Text",

--- a/packages/markdown-slate/test/data/acceptance.json
+++ b/packages/markdown-slate/test/data/acceptance.json
@@ -51,10 +51,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "shipper",
-                                    "value": "%22Party%20A%22"
+                                    "id": "shipper"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Party%20A%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -65,10 +67,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "receiver",
-                                    "value": "%22Party%20B%22"
+                                    "id": "receiver"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Party%20B%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -84,10 +88,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "deliverable",
-                                    "value": "%22Widgets%22"
+                                    "id": "deliverable"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Widgets%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -98,10 +104,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "receiver",
-                                    "value": "%22Party%20B%22"
+                                    "id": "receiver"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Party%20B%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -112,10 +120,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "shipper",
-                                    "value": "%22Party%20A%22"
+                                    "id": "shipper"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Party%20A%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -126,10 +136,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "deliverable",
-                                    "value": "%22Widgets%22"
+                                    "id": "deliverable"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Widgets%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -152,10 +164,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "receiver",
-                                    "value": "%22Party%20B%22"
+                                    "id": "receiver"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Party%20B%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -166,10 +180,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "businessDays",
-                                    "value": "10"
+                                    "id": "businessDays"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "10"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -190,10 +206,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "deliverable",
-                                    "value": "%22Widgets%22"
+                                    "id": "deliverable"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Widgets%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -204,10 +222,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "shipper",
-                                    "value": "%22Party%20A%22"
+                                    "id": "shipper"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Party%20A%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -218,10 +238,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "deliverable",
-                                    "value": "%22Widgets%22"
+                                    "id": "deliverable"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Widgets%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -264,10 +286,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "deliverable",
-                                    "value": "%22Widgets%22"
+                                    "id": "deliverable"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Widgets%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -278,10 +302,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "shipper",
-                                    "value": "%22Party%20A%22"
+                                    "id": "shipper"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Party%20A%22"
+                                }]
                             },
                             {
                                 "object": "text",
@@ -292,10 +318,12 @@
                                 "object": "inline",
                                 "type": "variable",
                                 "data": {
-                                    "id": "attachment",
-                                    "value": "%22Attachment%20X%22"
+                                    "id": "attachment"
                                 },
-                                "nodes": []
+                                "nodes": [{
+                                    "object": "text",
+                                    "text": "%22Attachment%20X%22"
+                                }]
                             },
                             {
                                 "object": "text",


### PR DESCRIPTION
# No issue

### Changes
Moving the `text` value from `data` to `nodes`

### Flags
- Unable to resolve these two failing tests:
  - https://github.com/accordproject/markdown-transform/blob/3878ac6253a92f9c50713c9ba8cbe42b04273f7a/packages/markdown-cli/test/cli.js#L87
  - https://github.com/accordproject/markdown-transform/blob/3878ac6253a92f9c50713c9ba8cbe42b04273f7a/packages/markdown-cli/test/cli.js#L55
- Resolved some failing tests (`packages/markdown-slate/src/SlateTransformer.test.js`) by adding `'marks': [],`, which doesn't seem like it was necessary. This lead to the remaining failing tests, which a text diff checker finds that the error is the included `'marks': [],`