### PR TITLE
#55 decodeURI in SlateDOM (will work for a t-shirt 😅)

### DIFF
--- a/packages/markdown-cicero/src/CiceroMarkTransformer.js
+++ b/packages/markdown-cicero/src/CiceroMarkTransformer.js
@@ -118,7 +118,7 @@ class CiceroMarkTransformer {
      * @param {object} [options] configuration options
      * @returns {*} json commonmark object
      */
-    toCommonMark(input, format='concerto', options) {
+    toCommonMark(input, format='concerto', options = {}) {
 
         if(!input.getType) {
             input = this.serializer.fromJSON(input);


### PR DESCRIPTION
# Issue #55

The encoding of the variables happens after serialization (from the `concerto-core` package), specifically this line in `CiceroMarkTransformer.js` from the `markdown-cicero` package
```
input = this.serializer.fromJSON(input);
```
The serialization in `concerto-core` looks very complicated so a simple `decodeURI()` will suffice.



### Changes
- Wrap the return of the `toMarkdown` method with a `decodeURI`
