### PR TITLE
fix(common) Remove extra newline when printing thematic breaks

### DIFF
--- a/packages/markdown-common/src/ToMarkdownStringVisitor.js
+++ b/packages/markdown-common/src/ToMarkdownStringVisitor.js
@@ -167,7 +167,7 @@ class ToMarkdownStringVisitor {
             break;
         case 'ThematicBreak':
             ToMarkdownStringVisitor.newBlock(parameters,2);
-            parameters.result += '---\n';
+            parameters.result += '---';
             break;
         case 'Linebreak':
             parameters.result += '\\\n';


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #99 

Cleanup of normalisation for thematic break (remove unnecessary new line).

