### PR TITLE
fix(ToHtmlStringVisitor): Replace emph with em tag

### DIFF
--- a/packages/markdown-html/src/ToHtmlStringVisitor.js
+++ b/packages/markdown-html/src/ToHtmlStringVisitor.js
@@ -111,7 +111,7 @@ class ToHtmlStringVisitor {
             parameters.result += thing.text;
             break;
         case 'Emph':
-            parameters.result += `<emph>${ToHtmlStringVisitor.visitChildren(this, thing)}</emph>`;
+            parameters.result += `<em>${ToHtmlStringVisitor.visitChildren(this, thing)}</em>`;
             break;
         case 'Strong':
             parameters.result += `<strong>${ToHtmlStringVisitor.visitChildren(this, thing)}</strong>`;

--- a/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
+++ b/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
@@ -587,7 +587,7 @@ exports[`html converts emph.md to html 2`] = `
 "<html>
 <body>
 <div class=\\"document\\">
-<p>This is <emph>some</emph> text.</p>
+<p>This is <em>some</em> text.</p>
 </div>
 </body>
 </html>"
@@ -633,7 +633,7 @@ exports[`html converts emph-strong.md to html 2`] = `
 "<html>
 <body>
 <div class=\\"document\\">
-<p>This is <emph><strong>some</strong></emph> text.</p>
+<p>This is <em><strong>some</strong></em> text.</p>
 </div>
 </body>
 </html>"


### PR DESCRIPTION
Replaces the invalid `emph` tag with `em` in the HTML string visitor