### PR TITLE
chore(deps): move slate to peerDep and devDep for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "markdown-transform",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/markdown-slate/README.md
+++ b/packages/markdown-slate/README.md
@@ -8,6 +8,11 @@ Use `SlateTransformer` to transform a CiceroMark DOM to/from a Slate DOM.
 npm install @accordproject/markdown-slate --save
 ```
 
+You'll also need to be sure to install this package's peer dependencies:
+```
+npm install slate immutable
+```
+
 ## Usage
 
 ``` javascript

--- a/packages/markdown-slate/package.json
+++ b/packages/markdown-slate/package.json
@@ -71,14 +71,17 @@
     "mocha": "6.1.4",
     "nyc": "14.1.1",
     "raw-loader": "^3.0.0",
+    "slate": "^0.47.8",
     "tsd-jsdoc": "^2.3.0",
     "webpack": "^4.35.0",
     "webpack-cli": "^3.3.5"
   },
   "dependencies": {
     "@accordproject/markdown-cicero": "0.7.4",
-    "immutable": "^4.0.0-rc.12",
-    "slate": "^0.47.7"
+    "immutable": "^4.0.0-rc.12"
+  },
+  "peerDependencies": {
+    "slate": "0.47.x"
   },
   "license-check-config": {
     "src": [

--- a/packages/markdown-slate/package.json
+++ b/packages/markdown-slate/package.json
@@ -64,6 +64,7 @@
     "chai-as-promised": "7.1.1",
     "chai-things": "0.2.0",
     "eslint": "6.0.1",
+    "immutable": "^4.0.0-rc.12",
     "jest": "^24.8.0",
     "jest-diff": "^24.8.0",
     "jsdoc": "3.6.3",
@@ -77,11 +78,11 @@
     "webpack-cli": "^3.3.5"
   },
   "dependencies": {
-    "@accordproject/markdown-cicero": "0.7.4",
-    "immutable": "^4.0.0-rc.12"
+    "@accordproject/markdown-cicero": "0.7.4"
   },
   "peerDependencies": {
-    "slate": "0.47.x"
+    "slate": "0.47.x",
+    "immutable": ">=3.8.1 || >4.0.0-rc"
   },
   "license-check-config": {
     "src": [


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>
- removes slate from dependencies
- adds slate as a peer dependency
- also adds slate as a dev dependency since it is needed for the tests
