### PR TITLE
fix(list) Does not add extraneous new lines in list (#110)

### DIFF
--- a/packages/markdown-common/src/ToMarkdownStringVisitor.js
+++ b/packages/markdown-common/src/ToMarkdownStringVisitor.js
@@ -195,8 +195,6 @@ class ToMarkdownStringVisitor {
         case 'List': {
             const first = thing.start ? parseInt(thing.start) : 1;
             let index = first;
-            // Always start with a new line
-            parameters.result += '\n';
             thing.nodes.forEach(item => {
                 const parametersIn = ToMarkdownStringVisitor.mkParametersInList(parameters);
                 if(thing.tight === 'false' && index !== first) {

--- a/packages/markdown-common/src/__snapshots__/CommonMarkTransformer.test.js.snap
+++ b/packages/markdown-common/src/__snapshots__/CommonMarkTransformer.test.js.snap
@@ -1434,6 +1434,103 @@ contents
 }
 `;
 
+exports[`markdown converts nested-list.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Prolog",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.List",
+      "delimiter": "period",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Item",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "item one",
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Item",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "item two",
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.List",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Item",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Paragraph",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "sublist",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.Item",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Paragraph",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "sublist",
+                        },
+                        Object {
+                          "$class": "org.accordproject.commonmark.Softbreak",
+                        },
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Epilog",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "tight": "true",
+              "type": "bullet",
+            },
+          ],
+        },
+      ],
+      "start": "1",
+      "tight": "true",
+      "type": "ordered",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts ol.md to concerto JSON 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",

--- a/packages/markdown-common/test/data/nested-list.md
+++ b/packages/markdown-common/test/data/nested-list.md
@@ -1,0 +1,6 @@
+Prolog
+1. item one
+2. item two
+   - sublist
+   - sublist
+Epilog


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #110 

- Remove extraneous new line at the beginning of lists which breaks the tight/not tight distinction in nested lists.
- Add corresponding nested list test
