### PR TITLE
fix(Slate) Does not fail on no children anymore (including empty list…

### DIFF
--- a/packages/markdown-slate/src/ToSlateVisitor.js
+++ b/packages/markdown-slate/src/ToSlateVisitor.js
@@ -110,7 +110,7 @@ class ToSlateVisitor {
     processChildNodes(thing) {
         const result = [];
         if(!thing.nodes) {
-            throw new Error(`Node ${thing.getType()} doesn't have any children!`);
+            thing.nodes = []; // Treat no nodes as empty array of nods
         }
 
         thing.nodes.forEach(node => {

--- a/packages/markdown-slate/src/__snapshots__/SlateTransformer.test.js.snap
+++ b/packages/markdown-slate/src/__snapshots__/SlateTransformer.test.js.snap
@@ -2098,6 +2098,10 @@ Object {
                     },
                   ],
                 },
+                Object {
+                  "$class": "org.accordproject.commonmark.Item",
+                  "nodes": Array [],
+                },
               ],
               "start": undefined,
               "tight": "true",
@@ -2131,6 +2135,7 @@ exports[`slate converts nested-list.json to and from CiceroMark 2`] = `
    - sublist
    - sublist
 with some text in the same paragraph
+   - 
 
 Epilog
 "
@@ -2250,6 +2255,12 @@ Object {
                     "object": "block",
                     "type": "list_item",
                   },
+                  Object {
+                    "data": Object {},
+                    "nodes": Array [],
+                    "object": "block",
+                    "type": "list_item",
+                  },
                 ],
                 "object": "block",
                 "type": "ul_list",
@@ -2362,6 +2373,10 @@ Object {
                       ],
                     },
                   ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.Item",
+                  "nodes": Array [],
                 },
               ],
               "start": undefined,

--- a/packages/markdown-slate/test/data/nested-list.json
+++ b/packages/markdown-slate/test/data/nested-list.json
@@ -116,6 +116,12 @@
                                                 ]
                                             }
                                         ]
+                                    },
+                                    {
+                                        "object": "block",
+                                        "type": "list_item",
+                                        "data": {},
+                                        "nodes": []
                                     }
                                 ]
                             }

--- a/packages/markdown-slate/test/data/nested-list.md
+++ b/packages/markdown-slate/test/data/nested-list.md
@@ -4,5 +4,6 @@ Prolog
    - sublist
    - sublist
 with some text in the same paragraph
+   - 
 
 Epilog


### PR DESCRIPTION
… items)

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #125
- Slate transform does not fail on missing children nodes anymore, instead treats those as empty list of children.
- Addresses issues with creating Slate DOM for empty list items
- `nested-list.md` test now include an empty list item
