### PR TITLE
fix(slate) only remove nodes with a single empty text node

### DIFF
--- a/packages/markdown-slate/src/slateToCiceroMarkDom.js
+++ b/packages/markdown-slate/src/slateToCiceroMarkDom.js
@@ -27,6 +27,7 @@ const removeEmptyParagraphs = (input) => {
     let nodesWithoutBlankParagraphs = [];
     input.nodes.forEach(node => {
         if (node.$class === 'org.accordproject.commonmark.Paragraph' &&
+            node.nodes.length === 1 &&
             node.nodes[0].$class === 'org.accordproject.commonmark.Text' &&
             node.nodes[0].text === '') {
             return;


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #147 
Fixes an issue with disappearing nods when one node contains a first node with empty text but more nodes after.

