### PR TITLE
fix(markdown-html): updates softbreaks

### DIFF
--- a/packages/markdown-html/src/ToHtmlStringVisitor.js
+++ b/packages/markdown-html/src/ToHtmlStringVisitor.js
@@ -138,7 +138,7 @@ class ToHtmlStringVisitor {
             parameters.result += '<br>\n';
             break;
         case 'Softbreak':
-            parameters.result += '<wbr>';
+            parameters.result += '\n';
             break;
         case 'Link':
             parameters.result += `<a href="${thing.destination}" title=${thing.title}>${ToHtmlStringVisitor.visitChildren(this, thing)}</a>`;

--- a/packages/markdown-html/src/ToHtmlStringVisitor.js
+++ b/packages/markdown-html/src/ToHtmlStringVisitor.js
@@ -135,7 +135,7 @@ class ToHtmlStringVisitor {
             parameters.result += '\n<hr>\n';
             break;
         case 'Linebreak':
-            parameters.result += '<br>\n';
+            parameters.result += '<br>';
             break;
         case 'Softbreak':
             parameters.result += '\n';

--- a/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
+++ b/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
@@ -398,10 +398,17 @@ exports[`html converts clause.md to html 2`] = `
 "<html>
 <body>
 <div class=\\"document\\">
-<p>This is a fixed interest loan to the amount of <span class=\\"variable\\" id=\\"loanAmount\\">100000.0</span><wbr>at the yearly interest rate of <span class=\\"variable\\" id=\\"rate\\">2.5</span>%<wbr>with a loan term of <span class=\\"variable\\" id=\\"loanDuration\\">15</span>,<wbr>and monthly payments of <span class=\\"computed\\">667.0</span></p>
-<p>This is a fixed interest loan to the amount of 100000.0<wbr>at the yearly interest rate of 2.5%<wbr>with a loan term of 15,<wbr>and monthly payments of 667.0</p>
+<p>This is a fixed interest loan to the amount of <span class=\\"variable\\" id=\\"loanAmount\\">100000.0</span>
+at the yearly interest rate of <span class=\\"variable\\" id=\\"rate\\">2.5</span>%
+with a loan term of <span class=\\"variable\\" id=\\"loanDuration\\">15</span>,
+and monthly payments of <span class=\\"computed\\">667.0</span></p>
+<p>This is a fixed interest loan to the amount of 100000.0
+at the yearly interest rate of 2.5%
+with a loan term of 15,
+and monthly payments of 667.0</p>
 <div class=\\"clause\\" clauseid=\\"bar\\" src=\\"foo\\">
-<p>this is<wbr>multiline <span class=\\"variable\\" id=\\"rate\\">2.5</span></p>
+<p>this is
+multiline <span class=\\"variable\\" id=\\"rate\\">2.5</span></p>
 <p>content</p>
 </div>
 </div>

--- a/packages/markdown-html/src/rules.js
+++ b/packages/markdown-html/src/rules.js
@@ -32,10 +32,18 @@ const TEXT_RULE = {
 
         // text nodes will be of type 3
         if (el.nodeType === 3 && !isIgnorable(el)) {
-            return {
-                '$class': `${NS_PREFIX_CommonMarkModel}${'Text'}`,
-                text: el.nodeValue,
-            };
+            const textArray = el.nodeValue.split('\n');
+            const textNodes =  textArray.map(text => {
+                if (text) {
+                    return {
+                        '$class': `${NS_PREFIX_CommonMarkModel}${'Text'}`,
+                        text,
+                    };
+                }
+            });
+
+            const result = [...textNodes].map((node, i) => i < textNodes.length - 1 ? [node, { '$class': `${NS_PREFIX_CommonMarkModel}${'Softbreak'}` }] : [node]).reduce((a, b) => a.concat(b)).filter(n => !!n);
+            return result;
         }
     }
 };


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

### Issue
- Currently, the transform uses `wbr` for softbreaks, which is not semantically correct and causes issues when rendering html in the browser

### Changes
- Uses `\n` for softbreaks instead of `wbr` when converting to html
- When converting from html, we find each `\n` inside of a text node and insert a softbreak node in its place

### Flags
- All of the tests currently pass. However, this could use more testing to make sure extraneous softbreaks do not get added where they shouldn't since we use `\n` in other parts of the transform as well.

Related to https://github.com/accordproject/cicero-template-library/pull/313