### PR TITLE
fix(codeblock) Properly create text from Slate code block to CiceroMark

### DIFF
--- a/packages/markdown-common/src/ToMarkdownStringVisitor.js
+++ b/packages/markdown-common/src/ToMarkdownStringVisitor.js
@@ -140,17 +140,17 @@ class ToMarkdownStringVisitor {
      * @param {*} parameters the parameters
      */
     visit(thing, parameters) {
-
+        const nodeText = thing.text ? thing.text : '';
         switch(thing.getType()) {
         case 'CodeBlock':
             ToMarkdownStringVisitor.newBlock(parameters,2);
-            parameters.result += `\`\`\`${thing.info ? ' ' + thing.info : ''}\n${ToMarkdownStringVisitor.escapeCodeBlock(thing.text)}\`\`\``;
+            parameters.result += `\`\`\`${thing.info ? ' ' + thing.info : ''}\n${ToMarkdownStringVisitor.escapeCodeBlock(nodeText)}\`\`\``;
             break;
         case 'Code':
-            parameters.result += `\`${thing.text}\``;
+            parameters.result += `\`${nodeText}\``;
             break;
         case 'HtmlInline':
-            parameters.result += thing.text;
+            parameters.result += nodeText;
             break;
         case 'Emph':
             parameters.result += `*${ToMarkdownStringVisitor.visitChildren(this, thing)}*`;
@@ -196,10 +196,10 @@ class ToMarkdownStringVisitor {
             break;
         case 'HtmlBlock':
             ToMarkdownStringVisitor.newBlock(parameters,2);
-            parameters.result += `${thing.text}`;
+            parameters.result += nodeText;
             break;
         case 'Text':
-            parameters.result += thing.text;
+            parameters.result += nodeText;
             break;
         case 'List': {
             const first = thing.start ? parseInt(thing.start) : 1;

--- a/packages/markdown-slate/src/__snapshots__/SlateTransformer.test.js.snap
+++ b/packages/markdown-slate/src/__snapshots__/SlateTransformer.test.js.snap
@@ -902,7 +902,10 @@ Object {
   "nodes": Array [
     Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
-      "text": undefined,
+      "text": "this
+is a
+code block.
+",
     },
     Object {
       "$class": "org.accordproject.commonmark.Paragraph",
@@ -982,7 +985,10 @@ Object {
   "nodes": Array [
     Object {
       "$class": "org.accordproject.commonmark.CodeBlock",
-      "text": undefined,
+      "text": "this
+is a
+code block.
+",
     },
     Object {
       "$class": "org.accordproject.commonmark.Paragraph",

--- a/packages/markdown-slate/src/slateToCiceroMarkDom.js
+++ b/packages/markdown-slate/src/slateToCiceroMarkDom.js
@@ -20,7 +20,7 @@ const NS_CICERO = 'org.accordproject.ciceromark';
 
 /**
  * Removes nodes if they are an empty paragraph
- * @param {*} input the current result of slateToCiceroMarkDom
+ * @param {*} input - the current result of slateToCiceroMarkDom
  * @returns {*} the final result of slateToCiceroMarkDom
  */
 const removeEmptyParagraphs = (input) => {
@@ -36,6 +36,24 @@ const removeEmptyParagraphs = (input) => {
     });
     input.nodes = nodesWithoutBlankParagraphs;
     return input;
+};
+
+/**
+ * Gather the text for the node
+ * @param {*} input - the current slate node
+ * @returns {string} the text contained in the slate node
+ */
+const getText = (input) => {
+    let result = '';
+    if (input.text) {
+        result += input.text;
+    }
+    if (input.nodes) {
+        input.nodes.forEach(node => {
+            result += getText(node);
+        });
+    }
+    return result;
 };
 
 /**
@@ -118,7 +136,7 @@ function _recursive(parent, nodes) {
                 result = {$class : `${NS}.BlockQuote`, nodes: []};
                 break;
             case 'code_block':
-                result = {$class : `${NS}.CodeBlock`, text: node.text};
+                result = {$class : `${NS}.CodeBlock`, text: getText(node)};
                 break;
             case 'html_block':
                 result = {$class : `${NS}.HtmlBlock`, text: node.text};


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #156
Addresses low level error when converting code blocks from Slate to Markdown.

### Changes
- More defensive access to node text in `markdown-transform`
- Proper creation of text field in CodeBlock when translating from slate.

### Flags
- Would be nice if the constraints that leaf nodes (Text, CodeBlock, etc) must have a text content and must node have children nodes was enforced by the CTO model.
