### PR TITLE
refactor(common) Safely copy parameters for paragraphs

### DIFF
--- a/packages/markdown-common/src/ToMarkdownStringVisitor.js
+++ b/packages/markdown-common/src/ToMarkdownStringVisitor.js
@@ -205,7 +205,8 @@ class ToMarkdownStringVisitor {
             break;
         case 'Paragraph':
             ToMarkdownStringVisitor.newBlock(parameters,2);
-            parameters.result += `${ToMarkdownStringVisitor.visitChildren(this, thing, parameters)}`;
+            const parametersIn = Object.assign(parameters);
+            parameters.result += `${ToMarkdownStringVisitor.visitChildren(this, thing, parametersIn)}`;
             break;
         case 'HtmlBlock':
             ToMarkdownStringVisitor.newBlock(parameters,2);


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #158 
- More defensive when passing parameters in for paragraphs (since it now passes parameters).
