### PR TITLE
fix(tomarkdown) Revised toMarkdown code to handle nested lists and ne…

### DIFF
--- a/packages/markdown-common/src/CommonMarkTransformer.js
+++ b/packages/markdown-common/src/CommonMarkTransformer.js
@@ -101,8 +101,7 @@ class CommonMarkTransformer {
         const parameters = {};
         parameters.result = '';
         parameters.first = true;
-        parameters.indent = 0;
-        parameters.blockIndent = 0;
+        parameters.stack = [];
         const visitor = new ToMarkdownStringVisitor(this.options);
         input.accept(visitor, parameters);
         return parameters.result.trim();
@@ -120,8 +119,7 @@ class CommonMarkTransformer {
         const parameters = {};
         parameters.result = '';
         parameters.first = true;
-        parameters.indent = 0;
-        parameters.blockIndent = 0;
+        parameters.stack = [];
         const visitor = new ToMarkdownStringVisitor(this.options);
         const result = ToMarkdownStringVisitor.visitChildren(visitor,input,parameters);
         // console.log('RESULT!' + result.trim());

--- a/packages/markdown-common/src/ToMarkdownStringVisitor.js
+++ b/packages/markdown-common/src/ToMarkdownStringVisitor.js
@@ -137,12 +137,23 @@ class ToMarkdownStringVisitor {
     }
 
     /**
-     * Adding escapes
+     * Adding escapes for code blocks
      * @param {string} input - unescaped
      * @return {string} escaped
      */
     static escapeCodeBlock(input) {
         return input.replace(/`/g, '\\`');
+    }
+
+    /**
+     * Adding escapes for text nodes
+     * @param {string} input - unescaped
+     * @return {string} escaped
+     */
+    static escapeText(input) {
+        return input.replace(/[*`#&]/g, '\\$&') // Replaces special characters
+            .replace(/^(\d+)\./g, '$1\\.') // Replaces ordered lists
+            .replace(/^-/g, '\\-'); // Replaces unordered lists
     }
 
     /**
@@ -155,7 +166,7 @@ class ToMarkdownStringVisitor {
         switch(thing.getType()) {
         case 'CodeBlock':
             parameters.result += ToMarkdownStringVisitor.mkPrefix(parameters,2);
-            parameters.result += `\`\`\`${thing.info ? ' ' + thing.info : ''}\n${ToMarkdownStringVisitor.escapeCodeBlock(nodeText)}\`\`\``;
+            parameters.result += `\`\`\`${thing.info ? ' ' + thing.info : ''}\n${ToMarkdownStringVisitor.escapeCodeBlock(thing.text)}\`\`\``;
             break;
         case 'Code':
             parameters.result += `\`${nodeText}\``;
@@ -213,7 +224,7 @@ class ToMarkdownStringVisitor {
             parameters.result += nodeText;
             break;
         case 'Text':
-            parameters.result += nodeText;
+            parameters.result += ToMarkdownStringVisitor.escapeText(nodeText);
             break;
         case 'List': {
             const first = thing.start ? parseInt(thing.start) : 1;

--- a/packages/markdown-common/src/__snapshots__/CommonMarkTransformer.test.js.snap
+++ b/packages/markdown-common/src/__snapshots__/CommonMarkTransformer.test.js.snap
@@ -1467,6 +1467,240 @@ contents
 }
 `;
 
+exports[`markdown converts neestedblockquote.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Once upon a time",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.BlockQuote",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is a",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Linebreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "linebreak.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is a quote.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Heading Two",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is more text.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Ordered lists:",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.List",
+          "delimiter": "period",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Item",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Paragraph",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "one",
+                    },
+                    Object {
+                      "$class": "org.accordproject.commonmark.Softbreak",
+                    },
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "this has more in it",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.List",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Item",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Paragraph",
+                          "nodes": Array [
+                            Object {
+                              "$class": "org.accordproject.commonmark.Text",
+                              "text": "nested list",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    Object {
+                      "$class": "org.accordproject.commonmark.Item",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Paragraph",
+                          "nodes": Array [
+                            Object {
+                              "$class": "org.accordproject.commonmark.Text",
+                              "text": "etc.",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                  "tight": "true",
+                  "type": "bullet",
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Item",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Paragraph",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "two",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Item",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Paragraph",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "three",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          "start": "1",
+          "tight": "true",
+          "type": "ordered",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This should be a line",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.ThematicBreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This should be more text",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.BlockQuote",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "This should be a nested blockquote",
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.Softbreak",
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "with more things in it",
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Paragraph",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": "And a second paragraph in the nested blockquote",
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "The end of the blockquote",
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "The end",
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts nested-list.md to concerto JSON 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",

--- a/packages/markdown-common/src/__snapshots__/CommonMarkTransformer.test.js.snap
+++ b/packages/markdown-common/src/__snapshots__/CommonMarkTransformer.test.js.snap
@@ -514,6 +514,24 @@ Object {
 }
 `;
 
+exports[`markdown converts codeblocknoescape.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.CodeBlock",
+      "text": "test
+more
+
+   xxx
+test
+",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts editor.md to concerto JSON 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
@@ -1076,6 +1094,97 @@ Object {
         Object {
           "$class": "org.accordproject.commonmark.Text",
           "text": "Heading Six",
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts headingdigit.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "1. This is a heading with a digit",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "This is another",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "1.",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Softbreak",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "heading",
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts headingdigit2.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "Regular text",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "2",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "1. Heading two",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "2",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "2. Heading two again",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "2",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "3. Heading two third",
         },
       ],
     },

--- a/packages/markdown-common/test/data/codeblocknoescape.md
+++ b/packages/markdown-common/test/data/codeblocknoescape.md
@@ -1,0 +1,7 @@
+```
+test
+more
+
+   xxx
+test
+```

--- a/packages/markdown-common/test/data/headingdigit.md
+++ b/packages/markdown-common/test/data/headingdigit.md
@@ -1,0 +1,6 @@
+# 1\. This is a heading with a digit
+
+This is another
+1\.
+heading
+====

--- a/packages/markdown-common/test/data/headingdigit2.md
+++ b/packages/markdown-common/test/data/headingdigit2.md
@@ -1,0 +1,7 @@
+Regular text
+
+## 1. Heading two
+
+## 2. Heading two again
+
+## 3. Heading two third

--- a/packages/markdown-common/test/data/listcodeblock.md
+++ b/packages/markdown-common/test/data/listcodeblock.md
@@ -1,5 +1,6 @@
 b) Discount. The Discount is determined according to the following table:
-```<list/>
+``` <list/>
 - <variable id="volumeAbove" value="1.0"/>$ million <= Volume < <variable id="volumeUpTo" value="10.0"/>$ million : <variable id="rate" value="3.1"/>%
 ```
+
 This is more text

--- a/packages/markdown-common/test/data/neestedblockquote.md
+++ b/packages/markdown-common/test/data/neestedblockquote.md
@@ -1,0 +1,29 @@
+Once upon a time
+
+> This is a\
+> linebreak.
+> This is a quote.
+>
+> Heading Two
+> ----
+> This is more text.
+> Ordered lists:
+> 1. one
+>    this has more in it
+>    - nested list
+>    - etc.
+> 2. two
+> 3. three
+>
+> This should be a line
+>
+> ----
+> This should be more text
+> > This should be a nested blockquote
+> with more things in it
+> >
+> > And a second paragraph in the nested blockquote
+>
+> The end of the blockquote
+
+The end


### PR DESCRIPTION
…sted blockquotes

Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #154 & #163 
A new approach to the `CommonMark.toMarkdown` generation, should properly handle nesting.
Also adds escaping for special characters.

### Changes
- Replaces indentation information by a stack of visited lists and blockquotes
- Creates newline transitions based on the stack, handling both list indentation and blockquotes
- Some test for the new approach with mode complex nesting and quotes content
- Special characters in text nodes (`#`, `.` `*` `` ` `` etc) are now being escaped.
