### PR TITLE
fix(Slate) HTML Blocks and Inlines now should roundtrip

### DIFF
--- a/packages/markdown-slate/src/ToSlateVisitor.js
+++ b/packages/markdown-slate/src/ToSlateVisitor.js
@@ -287,7 +287,6 @@ class ToSlateVisitor {
             };
             break;
         case 'HtmlBlock':
-        case 'HtmlInline':
             result = {
                 object: 'block',
                 type: 'html_block',
@@ -308,6 +307,16 @@ class ToSlateVisitor {
                     }],
                     data: {}
                 }]
+            };
+            break;
+        case 'HtmlInline':
+            result = {
+                object: 'inline',
+                type: 'html_inline',
+                data: {
+                    content: thing.text,
+                },
+                nodes: [] // XXX
             };
             break;
         case 'List':

--- a/packages/markdown-slate/src/__snapshots__/SlateTransformer.test.js.snap
+++ b/packages/markdown-slate/src/__snapshots__/SlateTransformer.test.js.snap
@@ -1634,7 +1634,12 @@ Object {
   "nodes": Array [
     Object {
       "$class": "org.accordproject.commonmark.HtmlBlock",
-      "text": undefined,
+      "text": "<foo>
+this
+is an
+html block.
+</foo>
+end.",
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -1698,7 +1703,12 @@ Object {
   "nodes": Array [
     Object {
       "$class": "org.accordproject.commonmark.HtmlBlock",
-      "text": undefined,
+      "text": "<foo>
+this
+is an
+html block.
+</foo>
+end.",
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",

--- a/packages/markdown-slate/src/slateToCiceroMarkDom.js
+++ b/packages/markdown-slate/src/slateToCiceroMarkDom.js
@@ -136,10 +136,10 @@ function _recursive(parent, nodes) {
                 result = {$class : `${NS}.CodeBlock`, text: getText(node)};
                 break;
             case 'html_block':
-                result = {$class : `${NS}.HtmlBlock`, text: node.text};
+                result = {$class : `${NS}.HtmlBlock`, text: getText(node)};
                 break;
             case 'html_inline':
-                result = {$class : `${NS}.HtmlInline`};
+                result = {$class : `${NS}.HtmlInline`, text: node.data.content};
                 break;
             case 'ol_list':
             case 'ul_list': {

--- a/packages/markdown-slate/test/data/html.md
+++ b/packages/markdown-slate/test/data/html.md
@@ -1,0 +1,5 @@
+This is text with <foo/> inside it
+
+<foo/>
+
+This is more text


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #150 #176 
- Bug fixes so that HTML Blocks roundtrip in Slate transform
- Add appropriate support for HTML Inlines in Slate transform

