### PR TITLE
refactor(slate) Remove slate dependency, relying on Slate JSON instead

### DIFF
--- a/packages/markdown-cli/package.json
+++ b/packages/markdown-cli/package.json
@@ -59,9 +59,7 @@
     "@accordproject/markdown-html": "0.9.10",
     "@accordproject/markdown-pdf": "0.9.10",
     "@accordproject/markdown-docx": "0.9.10",
-    "immutable": "^4.0.0-rc.12",
     "jsome": "2.5.0",
-    "slate": "^0.47.8",
     "winston": "3.2.1",
     "yargs": "13.2.4"
   },

--- a/packages/markdown-cli/test/data/acceptance-slate.json
+++ b/packages/markdown-cli/test/data/acceptance-slate.json
@@ -2,16 +2,13 @@
    "object":"value",
    "document":{
       "object":"document",
-      "data":{
-
-      },
       "nodes":[
          {
             "object":"block",
-            "type":"heading_one",
             "data":{
 
             },
+            "type":"heading_one",
             "nodes":[
                {
                   "object":"text",
@@ -25,9 +22,6 @@
          {
             "object":"block",
             "type":"paragraph",
-            "data":{
-
-            },
             "nodes":[
                {
                   "object":"text",
@@ -56,7 +50,10 @@
 
                   ]
                }
-            ]
+            ],
+            "data":{
+
+            }
          },
          {
             "object":"block",
@@ -69,9 +66,6 @@
                {
                   "object":"block",
                   "type":"paragraph",
-                  "data":{
-
-                  },
                   "nodes":[
                      {
                         "object":"text",
@@ -218,14 +212,14 @@
 
                         ]
                      }
-                  ]
+                  ],
+                  "data":{
+
+                  }
                },
                {
                   "object":"block",
                   "type":"paragraph",
-                  "data":{
-
-                  },
                   "nodes":[
                      {
                         "object":"text",
@@ -349,14 +343,14 @@
 
                         ]
                      }
-                  ]
+                  ],
+                  "data":{
+
+                  }
                },
                {
                   "object":"block",
                   "type":"paragraph",
-                  "data":{
-
-                  },
                   "nodes":[
                      {
                         "object":"text",
@@ -434,7 +428,10 @@
 
                         ]
                      }
-                  ]
+                  ],
+                  "data":{
+
+                  }
                }
             ]
          },
@@ -448,6 +445,9 @@
                  "marks": []
              }]
          }
-      ]
+      ],
+      "data":{
+
+      }
    }
 }

--- a/packages/markdown-slate/package.json
+++ b/packages/markdown-slate/package.json
@@ -65,7 +65,6 @@
     "chai-as-promised": "7.1.1",
     "chai-things": "0.2.0",
     "eslint": "6.0.1",
-    "immutable": "^4.0.0-rc.12",
     "jest": "^24.8.0",
     "jest-diff": "^24.8.0",
     "jsdoc": "3.6.3",
@@ -73,7 +72,6 @@
     "mocha": "6.1.4",
     "nyc": "14.1.1",
     "raw-loader": "^3.0.0",
-    "slate": "^0.47.8",
     "tsd-jsdoc": "^2.3.0",
     "webpack": "^4.35.0",
     "webpack-cli": "^3.3.5"

--- a/packages/markdown-slate/src/SlateTransformer.js
+++ b/packages/markdown-slate/src/SlateTransformer.js
@@ -14,7 +14,6 @@
 
 'use strict';
 
-const Value = require('slate').Value;
 const ToSlateVisitor = require('./ToSlateVisitor');
 const slateToCiceroMarkDom = require('./slateToCiceroMarkDom');
 const CiceroMarkTransformer = require('@accordproject/markdown-cicero').CiceroMarkTransformer;
@@ -88,7 +87,7 @@ class SlateTransformer {
         if (lastNodeType === CLAUSE) {
             result.document.nodes.push(paragraphSpaceNodeJSON);
         }
-        return Value.fromJSON(result);
+        return result;
     }
 
     /**

--- a/packages/markdown-slate/src/SlateTransformer.test.js
+++ b/packages/markdown-slate/src/SlateTransformer.test.js
@@ -17,7 +17,6 @@
 const fs = require('fs');
 const path = require('path');
 const SlateTransformer = require('./SlateTransformer');
-const Value = require('slate').Value;
 
 let slateTransformer = null;
 
@@ -51,8 +50,7 @@ function getSlateFiles() {
 describe('slate', () => {
     getSlateFiles().forEach( ([file, jsonText], index) => {
         it(`converts ${file} to and from CiceroMark`, () => {
-            const slateDom = JSON.parse(jsonText);
-            const value = Value.fromJSON(slateDom);
+            const value = JSON.parse(jsonText);
             const ciceroMark = slateTransformer.toCiceroMark(value, 'json');
 
             // check no changes to cicero mark
@@ -66,9 +64,9 @@ describe('slate', () => {
 
             // convert the expected markdown to cicero mark and compare
             const expectedSlateValue = slateTransformer.fromMarkdown(expectedMarkdown);
-            expect(expectedSlateValue.toJSON()).toMatchSnapshot(); // (3)
+            expect(expectedSlateValue).toMatchSnapshot(); // (3)
             // if(mdFile === 'image') {
-            //     console.log(JSON.stringify(expectedSlateValue.toJSON(), null, 4));
+            //     console.log(JSON.stringify(expectedSlateValue, null, 4));
             // }
 
             const expectedCiceroMark = slateTransformer.toCiceroMark(expectedSlateValue, 'json');
@@ -81,7 +79,7 @@ describe('slate', () => {
             expect(ciceroMark).toEqual(expectedCiceroMark);
 
             // check roundtrip
-            expect(expectedSlateValue.toJSON()).toEqual(value.toJSON());
+            expect(expectedSlateValue).toEqual(value);
         });
 
         it('converts variable to and from CiceroMark', () => {
@@ -120,12 +118,12 @@ describe('slate', () => {
                 }
             };
 
-            expect(slateValue.toJSON()).toEqual(expectedSlateValue);
+            expect(slateValue).toEqual(expectedSlateValue);
         });
 
         it('converts computed to and from CiceroMark', () => {
             const slateValue = slateTransformer.fromMarkdown('test <computed value="bar"/>');
-            //console.log(JSON.stringify(slateValue.toJSON(), null, 4));
+            //console.log(JSON.stringify(slateValue, null, 4));
             const expectedSlateValue = {
                 'object': 'value',
                 'document': {
@@ -158,7 +156,7 @@ describe('slate', () => {
                 }
             };
 
-            expect(slateValue.toJSON()).toEqual(expectedSlateValue);
+            expect(slateValue).toEqual(expectedSlateValue);
         });
     });
 });

--- a/packages/markdown-slate/src/ToSlateVisitor.js
+++ b/packages/markdown-slate/src/ToSlateVisitor.js
@@ -15,7 +15,7 @@
 'use strict';
 
 /**
- * Converts a CiceroMark DOM to a Slate DOM.
+ * Converts a CiceroMark DOM to a Slate JSON.
  */
 class ToSlateVisitor {
 
@@ -220,7 +220,8 @@ class ToSlateVisitor {
             result = {
                 object: 'block',
                 type: 'block_quote',
-                nodes: this.processChildNodes(thing,parameters)
+                nodes: this.processChildNodes(thing,parameters),
+                data: {}
             };
             break;
         case 'Heading':
@@ -272,7 +273,7 @@ class ToSlateVisitor {
                 'nodes': [
                     {
                         'object': 'text',
-                        'text': thing.text,
+                        'text': thing.text ? thing.text : '',
                         'marks': []
                     }
                 ]
@@ -353,6 +354,16 @@ class ToSlateVisitor {
             break;
         default:
             throw new Error(`Unhandled type ${thing.getType()}`);
+        }
+
+        // Cleanup block node for Slate
+        if (result.object === 'block' || result.object === 'inline') {
+            if (!result.data) {
+                result.data = {};
+            }
+            if (!result.nodes) {
+                result.nodes = [];
+            }
         }
 
         parameters.result = result;

--- a/packages/markdown-slate/src/slateToCiceroMarkDom.js
+++ b/packages/markdown-slate/src/slateToCiceroMarkDom.js
@@ -69,7 +69,7 @@ function slateToCiceroMarkDom(document) {
         nodes : []
     };
     // convert the value to a plain object
-    const json = JSON.parse(JSON.stringify(document));
+    const json = document;
     _recursive(result, json.nodes);
     return removeEmptyParagraphs(result);
 }

--- a/packages/markdown-slate/test/data/quote.json
+++ b/packages/markdown-slate/test/data/quote.json
@@ -6,6 +6,7 @@
         "nodes": [
             {
                 "object": "block",
+                "data": {},
                 "type": "block_quote",
                 "nodes": [
                     {


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

Disantangle markdown slate transformation from slate dependency, focusing on JSON representation.

### Flags
- This is a _non backward compatible change_ the code using the `markdown-slate` transform is now responsible for calling `Value.toJSON` and `Value.fromJSON` to get the Slate DOM.

### Related Issues
- Suggested as part of Issue #175 
