### PR TITLE
fix(slate) Remove now unnecessary peer dependencies on slate

### DIFF
--- a/packages/markdown-slate/package.json
+++ b/packages/markdown-slate/package.json
@@ -79,10 +79,6 @@
   "dependencies": {
     "@accordproject/markdown-cicero": "0.9.10"
   },
-  "peerDependencies": {
-    "slate": "0.47.x",
-    "immutable": ">=3.8.1 || >4.0.0-rc"
-  },
   "license-check-config": {
     "src": [
       "**/*.js",


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Remove unused peer dependencies on slate in the `markdown-slate` transform
