### PR TITLE
fix(HTML) Add support for conditional variables in HTML transform (#189)

### DIFF
--- a/packages/markdown-html/src/ToHtmlStringVisitor.js
+++ b/packages/markdown-html/src/ToHtmlStringVisitor.js
@@ -98,6 +98,9 @@ class ToHtmlStringVisitor {
         case 'Variable':
             parameters.result += `<span class="variable" id="${thing.id}">${thing.value}</span>`;
             break;
+        case 'ConditionalVariable':
+            parameters.result += `<span class="conditional" id="${thing.id}" whenTrue="${thing.whenTrue}" whenFalse="${thing.whenFalse}">${thing.value}</span>`;
+            break;
         case 'ComputedVariable':
             parameters.result += `<span class="computed">${thing.value}</span>`;
             break;

--- a/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
+++ b/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
@@ -905,6 +905,408 @@ exports[`html converts inline-code.md to html 2`] = `
 </html>"
 `;
 
+exports[`html converts latedelivery.md to html 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "clauseid": "87721b95-7e43-4441-82c7-b4d4db207e6f",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Late Delivery and Penalty.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "In case of delayed delivery",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.ConditionalVariable",
+              "id": "forceMajeure",
+              "value": " except for Force Majeure cases,",
+              "whenFalse": "",
+              "whenTrue": " except for Force Majeure cases,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "seller",
+              "value": "\\"Dan\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Seller) shall pay to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "buyer",
+              "value": "\\"Steve\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Buyer) for every ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "penaltyDuration",
+              "value": "2 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "of delay penalty amounting to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "penaltyPercentage",
+              "value": "10.5",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "whose delivery has been delayed. Any fractional part of a ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " is to be",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "considered a full ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ". The total amount of penalty shall not however,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "exceed ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "capPercentage",
+              "value": "55.0",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment involved in late delivery.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "If the delay is more than ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "termination",
+              "value": "15 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", the Buyer is entitled to terminate this Contract.",
+            },
+          ],
+        },
+      ],
+      "src": "https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`html converts latedelivery.md to html 2`] = `
+"<html>
+<body>
+<div class=\\"document\\">
+<h1>HELLO! This is the contract editor.</h1>
+<p>And below is a <strong>clause</strong>.</p>
+<div class=\\"clause\\" clauseid=\\"87721b95-7e43-4441-82c7-b4d4db207e6f\\" src=\\"https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta\\">
+<h2>Late Delivery and Penalty.</h2>
+<p>In case of delayed delivery<span class=\\"conditional\\" id=\\"forceMajeure\\" whenTrue=\\" except for Force Majeure cases,\\" whenFalse=\\"\\"> except for Force Majeure cases,</span>
+<span class=\\"variable\\" id=\\"seller\\">\\"Dan\\"</span> (the Seller) shall pay to <span class=\\"variable\\" id=\\"buyer\\">\\"Steve\\"</span> (the Buyer) for every <span class=\\"variable\\" id=\\"penaltyDuration\\">2 days</span>
+of delay penalty amounting to <span class=\\"variable\\" id=\\"penaltyPercentage\\">10.5</span>% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a <span class=\\"variable\\" id=\\"fractionalPart\\">days</span> is to be
+considered a full <span class=\\"variable\\" id=\\"fractionalPart\\">days</span>. The total amount of penalty shall not however,
+exceed <span class=\\"variable\\" id=\\"capPercentage\\">55.0</span>% of the total value of the Equipment involved in late delivery.
+If the delay is more than <span class=\\"variable\\" id=\\"termination\\">15 days</span>, the Buyer is entitled to terminate this Contract.</p>
+</div>
+</div>
+</body>
+</html>"
+`;
+
+exports[`html converts latedelivery-noforce.md to html 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "clauseid": "87721b95-7e43-4441-82c7-b4d4db207e6f",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Late Delivery and Penalty.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "In case of delayed delivery",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.ConditionalVariable",
+              "id": "forceMajeure",
+              "value": "",
+              "whenFalse": "",
+              "whenTrue": " except for Force Majeure cases,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "seller",
+              "value": "\\"Dan\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Seller) shall pay to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "buyer",
+              "value": "\\"Steve\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Buyer) for every ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "penaltyDuration",
+              "value": "2 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "of delay penalty amounting to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "penaltyPercentage",
+              "value": "10.5",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "whose delivery has been delayed. Any fractional part of a ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " is to be",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "considered a full ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ". The total amount of penalty shall not however,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "exceed ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "capPercentage",
+              "value": "55.0",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment involved in late delivery.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "If the delay is more than ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "termination",
+              "value": "15 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", the Buyer is entitled to terminate this Contract.",
+            },
+          ],
+        },
+      ],
+      "src": "https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`html converts latedelivery-noforce.md to html 2`] = `
+"<html>
+<body>
+<div class=\\"document\\">
+<h1>HELLO! This is the contract editor.</h1>
+<p>And below is a <strong>clause</strong>.</p>
+<div class=\\"clause\\" clauseid=\\"87721b95-7e43-4441-82c7-b4d4db207e6f\\" src=\\"https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta\\">
+<h2>Late Delivery and Penalty.</h2>
+<p>In case of delayed delivery<span class=\\"conditional\\" id=\\"forceMajeure\\" whenTrue=\\" except for Force Majeure cases,\\" whenFalse=\\"\\"></span>
+<span class=\\"variable\\" id=\\"seller\\">\\"Dan\\"</span> (the Seller) shall pay to <span class=\\"variable\\" id=\\"buyer\\">\\"Steve\\"</span> (the Buyer) for every <span class=\\"variable\\" id=\\"penaltyDuration\\">2 days</span>
+of delay penalty amounting to <span class=\\"variable\\" id=\\"penaltyPercentage\\">10.5</span>% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a <span class=\\"variable\\" id=\\"fractionalPart\\">days</span> is to be
+considered a full <span class=\\"variable\\" id=\\"fractionalPart\\">days</span>. The total amount of penalty shall not however,
+exceed <span class=\\"variable\\" id=\\"capPercentage\\">55.0</span>% of the total value of the Equipment involved in late delivery.
+If the delay is more than <span class=\\"variable\\" id=\\"termination\\">15 days</span>, the Buyer is entitled to terminate this Contract.</p>
+</div>
+</div>
+</body>
+</html>"
+`;
+
 exports[`html converts link.md to html 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",

--- a/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
+++ b/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
@@ -970,9 +970,6 @@ Object {
               "whenTrue": " except for Force Majeure cases,",
             },
             Object {
-              "$class": "org.accordproject.commonmark.Softbreak",
-            },
-            Object {
               "$class": "org.accordproject.ciceromark.Variable",
               "id": "seller",
               "value": "\\"Dan\\"",
@@ -1093,8 +1090,7 @@ exports[`html converts latedelivery.md to html 2`] = `
 <p>And below is a <strong>clause</strong>.</p>
 <div class=\\"clause\\" clauseid=\\"87721b95-7e43-4441-82c7-b4d4db207e6f\\" src=\\"https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta\\">
 <h2>Late Delivery and Penalty.</h2>
-<p>In case of delayed delivery<span class=\\"conditional\\" id=\\"forceMajeure\\" whenTrue=\\" except for Force Majeure cases,\\" whenFalse=\\"\\"> except for Force Majeure cases,</span>
-<span class=\\"variable\\" id=\\"seller\\">\\"Dan\\"</span> (the Seller) shall pay to <span class=\\"variable\\" id=\\"buyer\\">\\"Steve\\"</span> (the Buyer) for every <span class=\\"variable\\" id=\\"penaltyDuration\\">2 days</span>
+<p>In case of delayed delivery<span class=\\"conditional\\" id=\\"forceMajeure\\" whenTrue=\\" except for Force Majeure cases,\\" whenFalse=\\"\\"> except for Force Majeure cases,</span><span class=\\"variable\\" id=\\"seller\\">\\"Dan\\"</span> (the Seller) shall pay to <span class=\\"variable\\" id=\\"buyer\\">\\"Steve\\"</span> (the Buyer) for every <span class=\\"variable\\" id=\\"penaltyDuration\\">2 days</span>
 of delay penalty amounting to <span class=\\"variable\\" id=\\"penaltyPercentage\\">10.5</span>% of the total value of the Equipment
 whose delivery has been delayed. Any fractional part of a <span class=\\"variable\\" id=\\"fractionalPart\\">days</span> is to be
 considered a full <span class=\\"variable\\" id=\\"fractionalPart\\">days</span>. The total amount of penalty shall not however,
@@ -1169,9 +1165,6 @@ Object {
               "value": "",
               "whenFalse": "",
               "whenTrue": " except for Force Majeure cases,",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Softbreak",
             },
             Object {
               "$class": "org.accordproject.ciceromark.Variable",
@@ -1294,8 +1287,7 @@ exports[`html converts latedelivery-noforce.md to html 2`] = `
 <p>And below is a <strong>clause</strong>.</p>
 <div class=\\"clause\\" clauseid=\\"87721b95-7e43-4441-82c7-b4d4db207e6f\\" src=\\"https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta\\">
 <h2>Late Delivery and Penalty.</h2>
-<p>In case of delayed delivery<span class=\\"conditional\\" id=\\"forceMajeure\\" whenTrue=\\" except for Force Majeure cases,\\" whenFalse=\\"\\"></span>
-<span class=\\"variable\\" id=\\"seller\\">\\"Dan\\"</span> (the Seller) shall pay to <span class=\\"variable\\" id=\\"buyer\\">\\"Steve\\"</span> (the Buyer) for every <span class=\\"variable\\" id=\\"penaltyDuration\\">2 days</span>
+<p>In case of delayed delivery<span class=\\"conditional\\" id=\\"forceMajeure\\" whenTrue=\\" except for Force Majeure cases,\\" whenFalse=\\"\\"></span><span class=\\"variable\\" id=\\"seller\\">\\"Dan\\"</span> (the Seller) shall pay to <span class=\\"variable\\" id=\\"buyer\\">\\"Steve\\"</span> (the Buyer) for every <span class=\\"variable\\" id=\\"penaltyDuration\\">2 days</span>
 of delay penalty amounting to <span class=\\"variable\\" id=\\"penaltyPercentage\\">10.5</span>% of the total value of the Equipment
 whose delivery has been delayed. Any fractional part of a <span class=\\"variable\\" id=\\"fractionalPart\\">days</span> is to be
 considered a full <span class=\\"variable\\" id=\\"fractionalPart\\">days</span>. The total amount of penalty shall not however,

--- a/packages/markdown-html/src/rules.js
+++ b/packages/markdown-html/src/rules.js
@@ -315,6 +315,25 @@ const VARIABLE_RULE = {
 };
 
 /**
+ * A rule to deserialize conditional variable nodes.
+ * @type {Object}
+ */
+const CONDITIONAL_VARIABLE_RULE = {
+    deserialize(el, next) {
+        const { tagName } = el;
+        if (tagName && tagName.toLowerCase() === 'span' && el.getAttribute('class') === 'conditional') {
+            return {
+                '$class': `${NS_PREFIX_CiceroMarkModel}ConditionalVariable`,
+                id: el.getAttribute('id'),
+                whenTrue: el.getAttribute('whenTrue'),
+                whenFalse: el.getAttribute('whenFalse'),
+                value: el.textContent,
+            };
+        }
+    }
+};
+
+/**
  * A rule to deserialize computed variable nodes.
  * @type {Object}
  */
@@ -400,6 +419,7 @@ const rules = [
     BLOCK_QUOTE_RULE,
     CLAUSE_RULE,
     VARIABLE_RULE,
+    CONDITIONAL_VARIABLE_RULE,
     SOFTBREAK_RULE,
     COMPUTED_VARIABLE_RULE,
     TEXT_RULE,

--- a/packages/markdown-html/test/data/latedelivery-noforce.md
+++ b/packages/markdown-html/test/data/latedelivery-noforce.md
@@ -6,8 +6,7 @@ And below is a **clause**.
 Late Delivery and Penalty.
 ----
 
-In case of delayed delivery<if id="forceMajeure" value="" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" whenFalse=""/>
-<variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
+In case of delayed delivery<if id="forceMajeure" value="" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" whenFalse=""/><variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
 of delay penalty amounting to <variable id="penaltyPercentage" value="10.5"/>% of the total value of the Equipment
 whose delivery has been delayed. Any fractional part of a <variable id="fractionalPart" value="days"/> is to be
 considered a full <variable id="fractionalPart" value="days"/>. The total amount of penalty shall not however,

--- a/packages/markdown-html/test/data/latedelivery-noforce.md
+++ b/packages/markdown-html/test/data/latedelivery-noforce.md
@@ -1,0 +1,16 @@
+# HELLO! This is the contract editor. 
+
+And below is a **clause**.
+
+``` <clause src="https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta" clauseid="87721b95-7e43-4441-82c7-b4d4db207e6f">
+Late Delivery and Penalty.
+----
+
+In case of delayed delivery<if id="forceMajeure" value="" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" whenFalse=""/>
+<variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
+of delay penalty amounting to <variable id="penaltyPercentage" value="10.5"/>% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a <variable id="fractionalPart" value="days"/> is to be
+considered a full <variable id="fractionalPart" value="days"/>. The total amount of penalty shall not however,
+exceed <variable id="capPercentage" value="55.0"/>% of the total value of the Equipment involved in late delivery.
+If the delay is more than <variable id="termination" value="15%20days"/>, the Buyer is entitled to terminate this Contract.
+```

--- a/packages/markdown-html/test/data/latedelivery.md
+++ b/packages/markdown-html/test/data/latedelivery.md
@@ -1,0 +1,16 @@
+# HELLO! This is the contract editor. 
+
+And below is a **clause**.
+
+``` <clause src="https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta" clauseid="87721b95-7e43-4441-82c7-b4d4db207e6f">
+Late Delivery and Penalty.
+----
+
+In case of delayed delivery<if id="forceMajeure" value="%20except%20for%20Force%20Majeure%20cases%2C" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" whenFalse=""/>
+<variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
+of delay penalty amounting to <variable id="penaltyPercentage" value="10.5"/>% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a <variable id="fractionalPart" value="days"/> is to be
+considered a full <variable id="fractionalPart" value="days"/>. The total amount of penalty shall not however,
+exceed <variable id="capPercentage" value="55.0"/>% of the total value of the Equipment involved in late delivery.
+If the delay is more than <variable id="termination" value="15%20days"/>, the Buyer is entitled to terminate this Contract.
+```

--- a/packages/markdown-html/test/data/latedelivery.md
+++ b/packages/markdown-html/test/data/latedelivery.md
@@ -6,8 +6,7 @@ And below is a **clause**.
 Late Delivery and Penalty.
 ----
 
-In case of delayed delivery<if id="forceMajeure" value="%20except%20for%20Force%20Majeure%20cases%2C" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" whenFalse=""/>
-<variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
+In case of delayed delivery<if id="forceMajeure" value="%20except%20for%20Force%20Majeure%20cases%2C" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" whenFalse=""/><variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
 of delay penalty amounting to <variable id="penaltyPercentage" value="10.5"/>% of the total value of the Equipment
 whose delivery has been delayed. Any fractional part of a <variable id="fractionalPart" value="days"/> is to be
 considered a full <variable id="fractionalPart" value="days"/>. The total amount of penalty shall not however,


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #189 
- Add translation / rules for handling conditional variables in HTML transform

### Changes
- Rule to create HTML inline for conditional variables in CiceroMark -> HTML
- Rule to roundtrip back from HTML to CiceroMark
- Tests on late delivery and penalty clauses

### Flags
- This seems to trip possibly an unrelated bug about softbreaks. I'm leaving this as a draft PR until I can figure it out.
