### PR TITLE
feature(CLI) Add --plainText option to CLI

### DIFF
--- a/packages/markdown-cli/index.js
+++ b/packages/markdown-cli/index.js
@@ -101,6 +101,11 @@ require('yargs')
             type: 'boolean',
             default: false
         });
+        yargs.option('plainText', {
+            describe: 'do not use rich text formatting',
+            type: 'boolean',
+            default: false
+        });
         yargs.option('noWrap', {
             describe: 'do not wrap CiceroMark variables as XML tags',
             type: 'boolean',
@@ -127,6 +132,7 @@ require('yargs')
             options.cicero = argv.cicero;
             options.slate = argv.slate;
             options.html = argv.html;
+            options.plainText = argv.plainText;
             options.noWrap = argv.noWrap;
             options.noIndex = argv.noIndex;
             options.verbose = argv.verbose;
@@ -166,6 +172,11 @@ require('yargs')
             type: 'boolean',
             default: false
         });
+        yargs.option('plainText', {
+            describe: 'do not use rich text formatting',
+            type: 'boolean',
+            default: false
+        });
         yargs.option('noWrap', {
             describe: 'do not wrap variables as XML tags',
             type: 'boolean',
@@ -192,6 +203,7 @@ require('yargs')
             options.cicero = argv.cicero;
             options.slate = argv.slate;
             options.html = argv.html;
+            options.plainText = argv.plainText;
             options.noWrap = argv.noWrap;
             options.noIndex = argv.noIndex;
             options.verbose = argv.verbose;

--- a/packages/markdown-cli/lib/commands.js
+++ b/packages/markdown-cli/lib/commands.js
@@ -174,13 +174,14 @@ class Commands {
      * @param {object} [options] configuration options
      * @param {boolean} [options.cicero] whether to further transform for Cicero
      * @param {boolean} [options.slate] whether to further transform for Slate
+     * @param {boolean} [options.plainText] whether to remove rich text formatting
      * @param {boolean} [options.noWrap] whether to avoid wrapping Cicero variables in XML tags
      * @param {boolean} [options.noIndex] do not index ordered list (i.e., use 1. everywhere)
      * @param {boolean} [options.verbose] verbose output
      * @returns {object} Promise to the result of parsing
      */
     static draft(dataPath, outputPath, options) {
-        const { cicero, slate, html, noWrap, noIndex, verbose } = options;
+        const { cicero, slate, html, plainText, noWrap, noIndex, verbose } = options;
         const commonOptions = {};
         commonOptions.tagInfo = true;
         commonOptions.noIndex = noIndex ? true : false;
@@ -198,6 +199,7 @@ class Commands {
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
+            result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
                 Logger.info('=== CommonMark ===');
                 Logger.info(JSON.stringify(result, null, 4));
@@ -211,6 +213,7 @@ class Commands {
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
+            result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
                 Logger.info('=== CommonMark ===');
                 Logger.info(JSON.stringify(result, null, 4));
@@ -224,6 +227,7 @@ class Commands {
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
+            result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
                 Logger.info('=== CommonMark ===');
                 Logger.info(JSON.stringify(result, null, 4));
@@ -261,13 +265,14 @@ class Commands {
      * @param {object} [options] configuration options
      * @param {boolean} [options.cicero] whether to further transform for Cicero
      * @param {boolean} [options.slate] whether to further transform for Slate
+     * @param {boolean} [options.plainText] whether to remove rich text formatting
      * @param {boolean} [options.noWrap] whether to avoid wrapping Cicero variables in XML tags
      * @param {boolean} [options.noIndex] do not index ordered list (i.e., use 1. everywhere)
      * @param {boolean} [options.verbose] verbose output
      * @returns {object} Promise to the result of parsing
      */
     static normalize(samplePath, outputPath, options) {
-        const { cicero, slate, html, noWrap, noIndex, verbose } = options;
+        const { cicero, slate, html, plainText, noWrap, noIndex, verbose } = options;
         const commonOptions = {};
         commonOptions.tagInfo = true;
         commonOptions.noIndex = noIndex ? true : false;
@@ -279,6 +284,7 @@ class Commands {
 
         const markdownText = Fs.readFileSync(samplePath, 'utf8');
         let result = commonMark.fromMarkdown(markdownText, 'json');
+        result = plainText ? commonMark.removeFormatting(result) : result;
         if(verbose) {
             Logger.info('=== CommonMark ===');
             Logger.info(JSON.stringify(result, null, 4));
@@ -319,6 +325,7 @@ class Commands {
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
+            result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
                 Logger.info('=== CommonMark ===');
                 Logger.info(JSON.stringify(result, null, 4));
@@ -332,6 +339,7 @@ class Commands {
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
+            result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
                 Logger.info('=== CommonMark ===');
                 Logger.info(JSON.stringify(result, null, 4));
@@ -345,6 +353,7 @@ class Commands {
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
+            result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
                 Logger.info('=== CommonMark ===');
                 Logger.info(JSON.stringify(result, null, 4));


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #184 
Add a `--plainText` option to the `draft` and `normalize` commands in the CLI.

Example run:
```
bash-3.2$ cat test/data/nestedblockquote.md 
Once upon a time

> This is a\
> linebreak.
> This is a quote.
>
> Heading Two
> ----
> This is more text.
> Ordered lists:
> 1. one
>    this has more in it
>    - nested list
>    - etc.
> 2. two
> 3. three
>
> This should be a line
>
> ----
> This should be more text
> > This should be a nested blockquote
> with more things in it
> >
> > And a second paragraph in the nested blockquote
>
> The end of the blockquote

bash-3.2$ ../markdown-cli/index.js normalize --sample test/data/nestedblockquote.md  --plainText --cicero
9:26:36 PM - info: 
Once upon a time

This is alinebreak.This is a quote.

Heading Two

This is more text.Ordered lists:
1. one
   this has more in it
   -  nested list
   -  etc.
2. two
3. three

This should be a line

This should be more text

This should be a nested blockquotewith more things in it

And a second paragraph in the nested blockquote

The end of the blockquote

The end
bash-3.2$ ../markdown-cli/index.js parse --sample test/data/nestedblockquote.md --cicero --output data.json 
9:27:05 PM - info: Creating file: data.json
9:27:05 PM - info:
{
  "$class": "org.accordproject.commonmark.Document",
  "xmlns": "http://commonmark.org/xml/1.0",
  "nodes": [
    {
      "$class": "org.accordproject.commonmark.Paragraph",
      "nodes": [
        {
          "$class": "org.accordproject.commonmark.Text",
          "text": "Once upon a time"
        }
      ]
    }, 
.....
bash-3.2$ ../markdown-cli/index.js draft --data data.json --cicero --plainText 
9:27:25 PM - info: 
Once upon a time

This is alinebreak.This is a quote.

Heading Two

This is more text.Ordered lists:
1. one
   this has more in it
   -  nested list
   -  etc.
2. two
3. three

This should be a line

This should be more text

This should be a nested blockquotewith more things in it

And a second paragraph in the nested blockquote

The end of the blockquote

The end
```
