### PR TITLE
Reactor / Expand unquoting for variables

### DIFF
--- a/packages/markdown-cicero/src/CiceroMarkTransformer.js
+++ b/packages/markdown-cicero/src/CiceroMarkTransformer.js
@@ -51,8 +51,8 @@ class CiceroMarkTransformer {
      * Converts a markdown string to a CiceroMark DOM
      * @param {string} markdown a markdown string
      * @param {string} [format] result format, defaults to 'concerto'. Pass
-     * @param {object} [options] configuration options
      * 'json' to return the JSON data.
+     * @param {object} [options] configuration options
      * @returns {*} concertoObject concerto ciceromark object
      */
     fromMarkdown(markdown, format='concerto', options) {
@@ -87,7 +87,7 @@ class CiceroMarkTransformer {
         let result;
 
         // remove variables, e.g. {{ variable }}, {{% computed variable %}}
-        if(options && options.quoteVariables && !options.quoteVariables) {
+        if(options && Object.prototype.hasOwnProperty.call(options,'quoteVariables') && !options.quoteVariables) {
             result = unquoteVariables(json);
         } else {
             result = json;
@@ -149,7 +149,7 @@ class CiceroMarkTransformer {
      * 'json' to return the JSON data.
      * @param {object} [options] configuration options
      * @param {boolean} [options.removeFormatting] if true the formatting nodes are removed
-     * @param {boolean} [options.unquoteVariables] if true variable nodes are removed
+     * @param {boolean} [options.quoteVariables] if true variable nodes are removed
      * @returns {*} json commonmark object
      */
     toCommonMark(input, format='concerto', options) {
@@ -162,7 +162,7 @@ class CiceroMarkTransformer {
         }
 
         // remove variables, e.g. {{ variable }}, {{% computed variable %}}
-        if(options && options.quoteVariables && !options.quoteVariables) {
+        if(options && Object.prototype.hasOwnProperty.call(options,'quoteVariables') && !options.quoteVariables) {
             json = unquoteVariables(json);
         }
 

--- a/packages/markdown-cicero/src/CiceroMarkTransformer.test.js
+++ b/packages/markdown-cicero/src/CiceroMarkTransformer.test.js
@@ -165,7 +165,6 @@ describe('acceptance', () => {
         expect(ciceroMarkTransformer.getClauseText.bind(json.nodes[1], { wrapVariables: false})).toThrow('Cannot apply getClauseText to non-clause node');
     });
 
-
     it('converts acceptance clause content to CommonMark string (removeFormatting)', () => {
         const markdownText = fs.readFileSync(__dirname + '/../test/data/acceptance-formatted.md', 'utf8');
         const json = ciceroMarkTransformer.fromMarkdown(markdownText, 'json');
@@ -174,20 +173,29 @@ describe('acceptance', () => {
         expect(newMarkdown).toMatchSnapshot();
     });
 
-    it('converts acceptance clause content to CommonMark string (unquoteVariables)', () => {
+    it('converts acceptance clause content to CommonMark string (no quoteVariables)', () => {
         const markdownText = fs.readFileSync(__dirname + '/../test/data/acceptance-computed.md', 'utf8');
         const json = ciceroMarkTransformer.fromMarkdown(markdownText, 'json');
         expect(json).toMatchSnapshot();
-        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json', { unquoteVariables: true });
+        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json', { quoteVariables: false });
         expect(newMarkdown).toMatchSnapshot();
 
     });
 
-    it('converts acceptance clause content to CommonMark string (removeFormatting & unquoteVariables)', () => {
+    it('converts acceptance clause content to CommonMark string (no quoteVariables 2)', () => {
+        const markdownText = fs.readFileSync(__dirname + '/../test/data/acceptance-computed.md', 'utf8');
+        const json = ciceroMarkTransformer.fromMarkdown(markdownText, 'json', { quoteVariables: false });
+        expect(json).toMatchSnapshot();
+        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json');
+        expect(newMarkdown).toMatchSnapshot();
+
+    });
+
+    it('converts acceptance clause content to CommonMark string (removeFormatting & no quoteVariables)', () => {
         const markdownText = fs.readFileSync(__dirname + '/../test/data/acceptance-computed.md', 'utf8');
         const json = ciceroMarkTransformer.fromMarkdown(markdownText, 'json');
         expect(json).toMatchSnapshot();
-        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json', { removeFormatting: true, unquoteVariables: true });
+        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json', { removeFormatting: true, quoteVariables: false });
         expect(newMarkdown).toMatchSnapshot();
     });
 });

--- a/packages/markdown-cicero/src/CiceroMarkTransformer.test.js
+++ b/packages/markdown-cicero/src/CiceroMarkTransformer.test.js
@@ -174,20 +174,20 @@ describe('acceptance', () => {
         expect(newMarkdown).toMatchSnapshot();
     });
 
-    it('converts acceptance clause content to CommonMark string (unescapeExpressions)', () => {
+    it('converts acceptance clause content to CommonMark string (unquoteVariables)', () => {
         const markdownText = fs.readFileSync(__dirname + '/../test/data/acceptance-computed.md', 'utf8');
         const json = ciceroMarkTransformer.fromMarkdown(markdownText, 'json');
         expect(json).toMatchSnapshot();
-        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json', { unescapeExpressions: true });
+        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json', { unquoteVariables: true });
         expect(newMarkdown).toMatchSnapshot();
 
     });
 
-    it('converts acceptance clause content to CommonMark string (removeFormatting & unescapeExpressions)', () => {
+    it('converts acceptance clause content to CommonMark string (removeFormatting & unquoteVariables)', () => {
         const markdownText = fs.readFileSync(__dirname + '/../test/data/acceptance-computed.md', 'utf8');
         const json = ciceroMarkTransformer.fromMarkdown(markdownText, 'json');
         expect(json).toMatchSnapshot();
-        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json', { removeFormatting: true, unescapeExpressions: true });
+        const newMarkdown = ciceroMarkTransformer.toCommonMark(json, 'json', { removeFormatting: true, unquoteVariables: true });
         expect(newMarkdown).toMatchSnapshot();
     });
 });

--- a/packages/markdown-cicero/src/UnquoteVariables.js
+++ b/packages/markdown-cicero/src/UnquoteVariables.js
@@ -57,12 +57,12 @@ function mapObject(obj, stack) {
 }
 
 /**
-* Replaces Variable and Computed expressions with text nodes
+* Replaces variable and computed variables with text nodes
 * @param {*} input input object
 * @param {*} options options object
 * @returns {*} the modified object
 */
-function unescapeExpressions(input) {
+function unquoteVariables(input) {
     const root = {
         $class : 'org.accordproject.commonmark.Document',
         xmlns : input.xmlns,
@@ -74,4 +74,4 @@ function unescapeExpressions(input) {
     return root;
 }
 
-module.exports = unescapeExpressions;
+module.exports = unquoteVariables;

--- a/packages/markdown-cicero/src/__snapshots__/CiceroMarkTransformer.test.js.snap
+++ b/packages/markdown-cicero/src/__snapshots__/CiceroMarkTransformer.test.js.snap
@@ -1,5 +1,575 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`acceptance converts acceptance clause content to CommonMark string (no quoteVariables 2) 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "clauseid": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance of Delivery. ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Party A",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will be deemed to have completed its delivery obligations if in ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Party B",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "'s opinion, the ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Widgets",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " satisfies the Acceptance Criteria, and ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Party B",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " notifies ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Party A",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " in writing that it is accepting the ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Widgets",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Inspection and Notice. ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Party B",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will have ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "10",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " Business Days' to inspect and evaluate the ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Widgets",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " on the delivery date before notifying ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Party A",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " that it is either accepting or rejecting the ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Widgets",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Widgets",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " must meet for the ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Party A",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " to comply with its requirements and obligations under this agreement, detailed in ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Attachment X",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", attached to this agreement.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Widgets",
+            },
+          ],
+        },
+      ],
+      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`acceptance converts acceptance clause content to CommonMark string (no quoteVariables 2) 2`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.CodeBlock",
+      "info": "<clause src=\\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\"/>",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "src=\\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\"",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "src",
+            "value": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
+          },
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "clauseid",
+            "value": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+          },
+        ],
+        "closed": false,
+        "content": "Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
+
+Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
+
+This is Widgets",
+        "tagName": "clause",
+      },
+      "text": "Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
+
+Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
+
+This is Widgets
+",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`acceptance converts acceptance clause content to CommonMark string (no quoteVariables) 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "clauseid": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance of Delivery. ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will be deemed to have completed its delivery obligations if in ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "'s opinion, the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " satisfies the Acceptance Criteria, and ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " notifies ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " in writing that it is accepting the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Inspection and Notice. ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will have ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "businessDays",
+              "value": "10",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " Business Days' to inspect and evaluate the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " on the delivery date before notifying ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " that it is either accepting or rejecting the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " must meet for the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " to comply with its requirements and obligations under this agreement, detailed in ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "id": "attachment",
+              "value": "\\"Attachment X\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", attached to this agreement.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.ComputedVariable",
+              "value": "\\"Widgets\\"",
+            },
+          ],
+        },
+      ],
+      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`acceptance converts acceptance clause content to CommonMark string (no quoteVariables) 2`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.CodeBlock",
+      "info": "<clause src=\\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\"/>",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "src=\\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\"",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "src",
+            "value": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
+          },
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "clauseid",
+            "value": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+          },
+        ],
+        "closed": false,
+        "content": "Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
+
+Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
+
+This is Widgets",
+        "tagName": "clause",
+      },
+      "text": "Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
+
+Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
+
+This is Widgets
+",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`acceptance converts acceptance clause content to CommonMark string (no wrapVariable) 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
@@ -218,7 +788,7 @@ Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and 
 Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement."
 `;
 
-exports[`acceptance converts acceptance clause content to CommonMark string (removeFormatting & unquoteVariables) 1`] = `
+exports[`acceptance converts acceptance clause content to CommonMark string (removeFormatting & no quoteVariables) 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
   "nodes": Array [
@@ -432,7 +1002,7 @@ Object {
 }
 `;
 
-exports[`acceptance converts acceptance clause content to CommonMark string (removeFormatting & unquoteVariables) 2`] = `
+exports[`acceptance converts acceptance clause content to CommonMark string (removeFormatting & no quoteVariables) 2`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
   "nodes": Array [
@@ -481,22 +1051,22 @@ Object {
           },
         ],
         "closed": false,
-        "content": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".
+        "content": "Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
 
-Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".
+Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
 
-Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
 
-This is {{\\"Widgets\\"}}",
+This is Widgets",
         "tagName": "clause",
       },
-      "text": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".
+      "text": "Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
 
-Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".
+Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
 
-Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
 
-This is {{\\"Widgets\\"}}
+This is Widgets
 ",
     },
   ],
@@ -763,298 +1333,6 @@ The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\"
 must meet for the \\"Party A\\" to comply with its requirements and
 obligations under this agreement, detailed in \\"Attachment X\\", attached
 to this agreement.
-",
-    },
-  ],
-  "xmlns": "http://commonmark.org/xml/1.0",
-}
-`;
-
-exports[`acceptance converts acceptance clause content to CommonMark string (unquoteVariables) 1`] = `
-Object {
-  "$class": "org.accordproject.commonmark.Document",
-  "nodes": Array [
-    Object {
-      "$class": "org.accordproject.commonmark.Heading",
-      "level": "1",
-      "nodes": Array [
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": "HELLO! This is the contract editor.",
-        },
-      ],
-    },
-    Object {
-      "$class": "org.accordproject.commonmark.Paragraph",
-      "nodes": Array [
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": "And below is a ",
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Strong",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "clause",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": ".",
-        },
-      ],
-    },
-    Object {
-      "$class": "org.accordproject.ciceromark.Clause",
-      "clauseid": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
-      "nodes": Array [
-        Object {
-          "$class": "org.accordproject.commonmark.Paragraph",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "Acceptance of Delivery. ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "shipper",
-              "value": "\\"Party A\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " will be deemed to have completed its delivery obligations if in ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "receiver",
-              "value": "\\"Party B\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "'s opinion, the ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "deliverable",
-              "value": "\\"Widgets\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " satisfies the Acceptance Criteria, and ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "receiver",
-              "value": "\\"Party B\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " notifies ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "shipper",
-              "value": "\\"Party A\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " in writing that it is accepting the ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "deliverable",
-              "value": "\\"Widgets\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": ".",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Paragraph",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "Inspection and Notice. ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "receiver",
-              "value": "\\"Party B\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " will have ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "businessDays",
-              "value": "10",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " Business Days' to inspect and evaluate the ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "deliverable",
-              "value": "\\"Widgets\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " on the delivery date before notifying ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "shipper",
-              "value": "\\"Party A\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " that it is either accepting or rejecting the ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "deliverable",
-              "value": "\\"Widgets\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": ".",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Paragraph",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "deliverable",
-              "value": "\\"Widgets\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " must meet for the ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "shipper",
-              "value": "\\"Party A\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": " to comply with its requirements and obligations under this agreement, detailed in ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Variable",
-              "id": "attachment",
-              "value": "\\"Attachment X\\"",
-            },
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": ", attached to this agreement.",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Paragraph",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "This is ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.ComputedVariable",
-              "value": "\\"Widgets\\"",
-            },
-          ],
-        },
-      ],
-      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
-    },
-  ],
-  "xmlns": "http://commonmark.org/xml/1.0",
-}
-`;
-
-exports[`acceptance converts acceptance clause content to CommonMark string (unquoteVariables) 2`] = `
-Object {
-  "$class": "org.accordproject.commonmark.Document",
-  "nodes": Array [
-    Object {
-      "$class": "org.accordproject.commonmark.Heading",
-      "level": "1",
-      "nodes": Array [
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": "HELLO! This is the contract editor.",
-        },
-      ],
-    },
-    Object {
-      "$class": "org.accordproject.commonmark.Paragraph",
-      "nodes": Array [
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": "And below is a ",
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Strong",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "clause",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": ".",
-        },
-      ],
-    },
-    Object {
-      "$class": "org.accordproject.commonmark.CodeBlock",
-      "info": "<clause src=\\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\"/>",
-      "tag": Object {
-        "$class": "org.accordproject.commonmark.TagInfo",
-        "attributeString": "src=\\"ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f\\" clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\"",
-        "attributes": Array [
-          Object {
-            "$class": "org.accordproject.commonmark.Attribute",
-            "name": "src",
-            "value": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
-          },
-          Object {
-            "$class": "org.accordproject.commonmark.Attribute",
-            "name": "clauseid",
-            "value": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
-          },
-        ],
-        "closed": false,
-        "content": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".
-
-Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".
-
-Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.
-
-This is {{\\"Widgets\\"}}",
-        "tagName": "clause",
-      },
-      "text": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".
-
-Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".
-
-Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.
-
-This is {{\\"Widgets\\"}}
 ",
     },
   ],

--- a/packages/markdown-cicero/src/__snapshots__/CiceroMarkTransformer.test.js.snap
+++ b/packages/markdown-cicero/src/__snapshots__/CiceroMarkTransformer.test.js.snap
@@ -218,7 +218,7 @@ Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and 
 Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement."
 `;
 
-exports[`acceptance converts acceptance clause content to CommonMark string (removeFormatting & unescapeExpressions) 1`] = `
+exports[`acceptance converts acceptance clause content to CommonMark string (removeFormatting & unquoteVariables) 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
   "nodes": Array [
@@ -432,7 +432,7 @@ Object {
 }
 `;
 
-exports[`acceptance converts acceptance clause content to CommonMark string (removeFormatting & unescapeExpressions) 2`] = `
+exports[`acceptance converts acceptance clause content to CommonMark string (removeFormatting & unquoteVariables) 2`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
   "nodes": Array [
@@ -770,7 +770,7 @@ to this agreement.
 }
 `;
 
-exports[`acceptance converts acceptance clause content to CommonMark string (unescapeExpressions) 1`] = `
+exports[`acceptance converts acceptance clause content to CommonMark string (unquoteVariables) 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
   "nodes": Array [
@@ -984,7 +984,7 @@ Object {
 }
 `;
 
-exports[`acceptance converts acceptance clause content to CommonMark string (unescapeExpressions) 2`] = `
+exports[`acceptance converts acceptance clause content to CommonMark string (unquoteVariables) 2`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
   "nodes": Array [
@@ -1039,22 +1039,22 @@ Object {
           },
         ],
         "closed": false,
-        "content": "Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
+        "content": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".
 
-Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
+Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".
 
-Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.
 
-This is Widgets",
+This is {{\\"Widgets\\"}}",
         "tagName": "clause",
       },
-      "text": "Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
+      "text": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".
 
-Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
+Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".
 
-Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.
 
-This is Widgets
+This is {{\\"Widgets\\"}}
 ",
     },
   ],

--- a/packages/markdown-cli/index.js
+++ b/packages/markdown-cli/index.js
@@ -48,6 +48,11 @@ require('yargs')
             type: 'boolean',
             default: false
         });
+        yargs.option('noQuote', {
+            describe: 'do use quotes for CiceroMark variables',
+            type: 'boolean',
+            default: false
+        });
         yargs.option('verbose', {
             describe: 'verbose output',
             type: 'boolean',
@@ -64,6 +69,7 @@ require('yargs')
             options.cicero = argv.cicero;
             options.slate = argv.slate;
             options.html = argv.html;
+            options.noQuote = argv.noQuote;
             options.verbose = argv.verbose;
             return Commands.parse(argv.sample, argv.output, options)
                 .then((result) => {
@@ -111,6 +117,11 @@ require('yargs')
             type: 'boolean',
             default: false
         });
+        yargs.option('noQuote', {
+            describe: 'do use quotes for CiceroMark variables',
+            type: 'boolean',
+            default: false
+        });
         yargs.option('noIndex', {
             describe: 'do not index ordered lists',
             type: 'boolean',
@@ -134,6 +145,7 @@ require('yargs')
             options.html = argv.html;
             options.plainText = argv.plainText;
             options.noWrap = argv.noWrap;
+            options.noQuote = argv.noQuote;
             options.noIndex = argv.noIndex;
             options.verbose = argv.verbose;
             return Commands.draft(argv.data, argv.output, options)
@@ -182,6 +194,11 @@ require('yargs')
             type: 'boolean',
             default: false
         });
+        yargs.option('noQuote', {
+            describe: 'do use quotes for CiceroMark variables',
+            type: 'boolean',
+            default: false
+        });
         yargs.option('noIndex', {
             describe: 'do not index ordered lists',
             type: 'boolean',
@@ -205,6 +222,7 @@ require('yargs')
             options.html = argv.html;
             options.plainText = argv.plainText;
             options.noWrap = argv.noWrap;
+            options.noQuote = argv.noQuote;
             options.noIndex = argv.noIndex;
             options.verbose = argv.verbose;
             return Commands.normalize(argv.sample, argv.output, options)

--- a/packages/markdown-cli/lib/commands.js
+++ b/packages/markdown-cli/lib/commands.js
@@ -79,11 +79,13 @@ class Commands {
      * @param {boolean} [options.cicero] whether to further transform for Cicero
      * @param {boolean} [options.slate] whether to further transform for Slate
      * @param {boolean} [options.html] whether to further transform for HTML
+     * @param {boolean} [options.noQuote] whether to avoid quoting Cicero variables
      * @param {boolean} [options.verbose] verbose output
      * @returns {object} Promise to the result of parsing
      */
     static async parse(samplePath, outputPath, options) {
-        const { cicero, slate, html, verbose } = options;
+        const { cicero, slate, html, noQuote, verbose } = options;
+        console.log('OPTIONS ' + JSON.stringify(options));
         const commonOptions = {};
         commonOptions.tagInfo = true;
 
@@ -114,30 +116,22 @@ class Commands {
             Logger.info(JSON.stringify(result, null, 4));
         }
 
-        if (cicero) {
-            result = ciceroMark.fromCommonMark(result, 'json');
+        if (cicero || slate || html) {
+            const ciceroOptions = {};
+            ciceroOptions.quoteVariables = noQuote ? false : true;
+            result = ciceroMark.fromCommonMark(result, 'json', ciceroOptions);
             if(verbose) {
                 Logger.info('=== CiceroMark ===');
                 Logger.info(JSON.stringify(result, null, 4));
             }
         }
-        else if (slate) {
-            result = ciceroMark.fromCommonMark(result, 'json');
-            if(verbose) {
-                Logger.info('=== CiceroMark ===');
-                Logger.info(JSON.stringify(result, null, 4));
-            }
+        if (slate) {
             result = slateMark.fromCiceroMark(result);
             if(verbose) {
                 Logger.info('=== Slate DOM ===');
                 Logger.info(JSON.stringify(result, null, 4));
             }
         } else if (html) {
-            result = ciceroMark.fromCommonMark(result, 'json');
-            if(verbose) {
-                Logger.info('=== CiceroMark ===');
-                Logger.info(JSON.stringify(result, null, 4));
-            }
             result = htmlMark.toHtml(result);
         }
         if (!html) {
@@ -176,12 +170,13 @@ class Commands {
      * @param {boolean} [options.slate] whether to further transform for Slate
      * @param {boolean} [options.plainText] whether to remove rich text formatting
      * @param {boolean} [options.noWrap] whether to avoid wrapping Cicero variables in XML tags
+     * @param {boolean} [options.noQuote] whether to avoid quoting Cicero variables
      * @param {boolean} [options.noIndex] do not index ordered list (i.e., use 1. everywhere)
      * @param {boolean} [options.verbose] verbose output
      * @returns {object} Promise to the result of parsing
      */
     static draft(dataPath, outputPath, options) {
-        const { cicero, slate, html, plainText, noWrap, noIndex, verbose } = options;
+        const { cicero, slate, html, plainText, noWrap, noQuote, noIndex, verbose } = options;
         const commonOptions = {};
         commonOptions.tagInfo = true;
         commonOptions.noIndex = noIndex ? true : false;
@@ -198,6 +193,7 @@ class Commands {
         if (cicero) {
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
+            ciceroOptions.quoteVariables = noQuote ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
             result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
@@ -212,6 +208,7 @@ class Commands {
             }
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
+            ciceroOptions.quoteVariables = noQuote ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
             result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
@@ -226,6 +223,7 @@ class Commands {
             }
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
+            ciceroOptions.quoteVariables = noQuote ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
             result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
@@ -267,12 +265,13 @@ class Commands {
      * @param {boolean} [options.slate] whether to further transform for Slate
      * @param {boolean} [options.plainText] whether to remove rich text formatting
      * @param {boolean} [options.noWrap] whether to avoid wrapping Cicero variables in XML tags
+     * @param {boolean} [options.noQuote] whether to avoid quoting Cicero variables
      * @param {boolean} [options.noIndex] do not index ordered list (i.e., use 1. everywhere)
      * @param {boolean} [options.verbose] verbose output
      * @returns {object} Promise to the result of parsing
      */
     static normalize(samplePath, outputPath, options) {
-        const { cicero, slate, html, plainText, noWrap, noIndex, verbose } = options;
+        const { cicero, slate, html, plainText, noWrap, noQuote, noIndex, verbose } = options;
         const commonOptions = {};
         commonOptions.tagInfo = true;
         commonOptions.noIndex = noIndex ? true : false;
@@ -290,31 +289,22 @@ class Commands {
             Logger.info(JSON.stringify(result, null, 4));
         }
 
-        if (cicero) {
-            result = ciceroMark.fromCommonMark(result, 'json');
+        if (cicero || slate || html) {
+            const ciceroOptions = {};
+            ciceroOptions.quoteVariables = noQuote ? false : true;
+            result = ciceroMark.fromCommonMark(result, 'json', ciceroOptions);
             if(verbose) {
                 Logger.info('=== CiceroMark ===');
                 Logger.info(JSON.stringify(result, null, 4));
             }
         }
-        else if (slate) {
-            result = ciceroMark.fromCommonMark(result, 'json');
-            if(verbose) {
-                Logger.info('=== CiceroMark ===');
-                Logger.info(JSON.stringify(result, null, 4));
-            }
+        if (slate) {
             result = slateMark.fromCiceroMark(result);
             if(verbose) {
                 Logger.info('=== Slate DOM ===');
                 Logger.info(JSON.stringify(result, null, 4));
             }
-        }
-        else if (html) {
-            result = ciceroMark.fromCommonMark(result, 'json');
-            if(verbose) {
-                Logger.info('=== CiceroMark ===');
-                Logger.info(JSON.stringify(result, null, 4));
-            }
+        } else if (html) {
             result = htmlMark.toHtml(result);
             if(verbose) {
                 Logger.info('=== HTML ===');
@@ -324,6 +314,7 @@ class Commands {
         if (cicero) {
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
+            ciceroOptions.quoteVariables = noQuote ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
             result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
@@ -338,6 +329,7 @@ class Commands {
             }
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
+            ciceroOptions.quoteVariables = noQuote ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
             result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {
@@ -352,6 +344,7 @@ class Commands {
             }
             const ciceroOptions = {};
             ciceroOptions.wrapVariables = noWrap ? false : true;
+            ciceroOptions.quoteVariables = noQuote ? false : true;
             result = ciceroMark.toCommonMark(result, 'json', ciceroOptions);
             result = plainText ? commonMark.removeFormatting(result) : result;
             if(verbose) {


### PR DESCRIPTION
### Changes
- Name change: from `unescapeExpressions` to `unquoteVariables`, using the same model as `unwrapVariables
- Allow unescape expressions both on the to cicero and from cicero route (for e.g., HTML)
- Some more testing
- Adds `--unquoteVariables` as an option to the CLI
- A bit of CLI simplification
