### PR TITLE
chore(cicero) More testing, adjust API, remove unused code

### DIFF
--- a/packages/markdown-cicero/lib/CiceroEditTransformer.test.js
+++ b/packages/markdown-cicero/lib/CiceroEditTransformer.test.js
@@ -105,4 +105,41 @@ describe('acceptance', () => {
         const newMarkdown = ciceroMarkTransformer.toMarkdownCicero(jsonUnwrapped);
         expect(newMarkdown).toMatchSnapshot();
     });
+
+    it('converts acceptance to markdown string (unquoted)', () => {
+        const markdownText = fs.readFileSync(__dirname + '/../test/data/ciceroedit/acceptance.md', 'utf8');
+        const json = ciceroMarkTransformer.fromCiceroEdit(markdownText);
+        // console.log(JSON.stringify(json, null, 4));
+        expect(json).toMatchSnapshot();
+        const newMarkdown = ciceroMarkTransformer.toMarkdown(json,{unquoteVariables:true});
+        expect(newMarkdown).toMatchSnapshot();
+    });
+
+    it('converts acceptance-formula to markdown string', () => {
+        const markdownText = fs.readFileSync(__dirname + '/../test/data/ciceroedit/acceptance-formula.md', 'utf8');
+        const json = ciceroMarkTransformer.fromCiceroEdit(markdownText);
+        // console.log(JSON.stringify(json, null, 4));
+        expect(json).toMatchSnapshot();
+        const newMarkdown = ciceroMarkTransformer.toMarkdown(json);
+        expect(newMarkdown).toMatchSnapshot();
+    });
+
+    it('converts acceptance-formula to markdown string (unquoted)', () => {
+        const markdownText = fs.readFileSync(__dirname + '/../test/data/ciceroedit/acceptance-formula.md', 'utf8');
+        const json = ciceroMarkTransformer.fromCiceroEdit(markdownText);
+        // console.log(JSON.stringify(json, null, 4));
+        expect(json).toMatchSnapshot();
+        const newMarkdown = ciceroMarkTransformer.toMarkdown(json,{unquoteVariables:true});
+        expect(newMarkdown).toMatchSnapshot();
+    });
+
+    it('converts acceptance-notclause2 to markdown string', () => {
+        const markdownText = fs.readFileSync(__dirname + '/../test/data/ciceroedit/acceptance-notclause2.md', 'utf8');
+        const json = ciceroMarkTransformer.fromCiceroEdit(markdownText);
+        // console.log(JSON.stringify(json, null, 4));
+        expect(json).toMatchSnapshot();
+        const newMarkdown = ciceroMarkTransformer.toMarkdown(json,{unquoteVariables:true});
+        expect(newMarkdown).toMatchSnapshot();
+    });
+
 });

--- a/packages/markdown-cicero/lib/CiceroMarkTransformer.test.js
+++ b/packages/markdown-cicero/lib/CiceroMarkTransformer.test.js
@@ -78,6 +78,10 @@ function getMarkdownFiles() {
 }
 
 describe('markdown', () => {
+    it('transformer should have a serializer', () => {
+        expect(ciceroMarkTransformer.getSerializer()).toBeTruthy();
+    });
+
     getMarkdownFiles().forEach( ([file, markdownText]) => {
         it(`converts ${file} to concerto`, () => {
             const json = ciceroMarkTransformer.fromMarkdownCicero(markdownText, 'json');
@@ -105,7 +109,16 @@ describe('acceptance', () => {
         const json = ciceroMarkTransformer.fromMarkdownCicero(markdownText);
         // console.log(JSON.stringify(json, null, 4));
         expect(json).toMatchSnapshot();
-        const newMarkdown = ciceroMarkTransformer.toMarkdown(json,{quoteVariables:false});
+        const newMarkdown = ciceroMarkTransformer.toMarkdown(json,{unquoteVariables:true});
+        expect(newMarkdown).toMatchSnapshot();
+    });
+
+    it('converts acceptance to markdown string (plaintext)', () => {
+        const markdownText = fs.readFileSync(__dirname + '/../test/data/ciceromark/acceptance.md', 'utf8');
+        const json = ciceroMarkTransformer.fromMarkdownCicero(markdownText);
+        // console.log(JSON.stringify(json, null, 4));
+        expect(json).toMatchSnapshot();
+        const newMarkdown = ciceroMarkTransformer.toMarkdown(json,{removeFormatting:true});
         expect(newMarkdown).toMatchSnapshot();
     });
 

--- a/packages/markdown-cicero/lib/FromCiceroEditVisitor.js
+++ b/packages/markdown-cicero/lib/FromCiceroEditVisitor.js
@@ -20,18 +20,6 @@ const { NS_PREFIX_CiceroMarkModel } = require('./externalModels/CiceroMarkModel'
  * Converts a CommonMark DOM to a CiceroMark DOM
  */
 class FromCiceroEditVisitor {
-
-    /**
-     * Remove newline which is part of the code block markup
-     * @param {string} text - the code block text in the AST
-     * @return {string} the code block text without the new line due to markup
-     */
-    static codeBlockContent(text) {
-        // Remove last new line, needed by CommonMark parser to identify ending code block (\n```)
-        const result = text.charAt(text.length - 1) === '\n' ? text.substring(0, text.length - 1) : text;
-        return result;
-    }
-
     /**
      * Visits a sub-tree and return CiceroMark DOM
      * @param {*} visitor the visitor to use
@@ -68,7 +56,7 @@ class FromCiceroEditVisitor {
             if (tag && tag.tagName === 'clause' && tag.attributes.length === 2) {
                 const ciceroMarkTag = NS_PREFIX_CiceroMarkModel + 'Clause';
                 // Remove last new line, needed by CommonMark parser to identify ending code block (\n```)
-                const clauseText = FromCiceroEditVisitor.codeBlockContent(thing.text);
+                const clauseText = thing.text;
 
                 //console.log('CONTENT! : ' + tag.content);
                 if (FromCiceroEditVisitor.getAttribute(tag.attributes, 'src') &&
@@ -88,9 +76,9 @@ class FromCiceroEditVisitor {
             } else if (tag && tag.tagName === 'list' && tag.attributes.length === 0) {
                 const ciceroMarkTag = NS_PREFIX_CiceroMarkModel + 'ListBlock';
                 // Remove last new line, needed by CommonMark parser to identify ending code block (\n```)
-                const clauseText = FromCiceroEditVisitor.codeBlockContent(thing.text);
+                const listText = thing.text;
 
-                const commonMark = parameters.commonMark.fromMarkdown(clauseText);
+                const commonMark = parameters.commonMark.fromMarkdown(listText);
                 const newNodes = parameters.serializer.fromJSON(commonMark).nodes;
                 if (newNodes.length === 1 && newNodes[0].getType() === 'List') {
                     const listNode = newNodes[0];

--- a/packages/markdown-cicero/lib/__snapshots__/CiceroEditTransformer.test.js.snap
+++ b/packages/markdown-cicero/lib/__snapshots__/CiceroEditTransformer.test.js.snap
@@ -216,7 +216,7 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
 {{/clause}}"
 `;
 
-exports[`markdown converts acceptance.md to ciceromark 1`] = `
+exports[`acceptance converts acceptance to markdown string (unquoted) 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
   "nodes": Array [
@@ -417,7 +417,20 @@ Object {
 }
 `;
 
-exports[`markdown converts acceptance-computed.md to ciceromark 1`] = `
+exports[`acceptance converts acceptance to markdown string (unquoted) 2`] = `
+"HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
+
+Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement."
+`;
+
+exports[`acceptance converts acceptance-formula to markdown string (unquoted) 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
   "nodes": Array [
@@ -621,6 +634,537 @@ Object {
               "$class": "org.accordproject.ciceromark.Formula",
               "name": "",
               "value": "\\"Widgets\\"",
+            },
+          ],
+        },
+      ],
+      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`acceptance converts acceptance-formula to markdown string (unquoted) 2`] = `
+"HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+Acceptance of Delivery. Party A will be deemed to have completed its delivery obligations if in Party B's opinion, the Widgets satisfies the Acceptance Criteria, and Party B notifies Party A in writing that it is accepting the Widgets.
+
+Inspection and Notice. Party B will have 10 Business Days' to inspect and evaluate the Widgets on the delivery date before notifying Party A that it is either accepting or rejecting the Widgets.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the Widgets must meet for the Party A to comply with its requirements and obligations under this agreement, detailed in Attachment X, attached to this agreement.
+
+This is Widgets"
+`;
+
+exports[`acceptance converts acceptance-formula to markdown string 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance of Delivery. ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will be deemed to have completed its delivery obligations if in ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "'s opinion, the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " satisfies the Acceptance Criteria, and ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " notifies ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " in writing that it is accepting the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Inspection and Notice. ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will have ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "businessDays",
+              "value": "10",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " Business Days' to inspect and evaluate the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " on the delivery date before notifying ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " that it is either accepting or rejecting the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " must meet for the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " to comply with its requirements and obligations under this agreement, detailed in ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "attachment",
+              "value": "\\"Attachment X\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", attached to this agreement.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Formula",
+              "name": "",
+              "value": "\\"Widgets\\"",
+            },
+          ],
+        },
+      ],
+      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`acceptance converts acceptance-formula to markdown string 2`] = `
+"HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".
+
+Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.
+
+This is \\"Widgets\\""
+`;
+
+exports[`acceptance converts acceptance-notclause2 to markdown string 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.CodeBlock",
+      "info": "<clause clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" FOO=\\"something\\">",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "clauseid = \\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" FOO = \\"something\\" ",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "clauseid",
+            "value": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+          },
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "FOO",
+            "value": "something",
+          },
+        ],
+        "closed": false,
+        "content": "",
+        "tagName": "clause",
+      },
+      "text": "Acceptance of Delivery. <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> will be deemed to have completed its delivery obligations if in <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/>'s opinion, the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> satisfies the Acceptance Criteria, and <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> notifies <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> in writing that it is accepting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
+
+Inspection and Notice. <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> will have <variable id=\\"businessDays\\" value=\\"10\\"/> Business Days' to inspect and evaluate the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> on the delivery date before notifying <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> that it is either accepting or rejecting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> must meet for the <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> to comply with its requirements and obligations under this agreement, detailed in <variable id=\\"attachment\\" value=\\"%22Attachment%20X%22\\"/>, attached to this agreement.
+",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`acceptance converts acceptance-notclause2 to markdown string 2`] = `
+"HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+\`\`\` <clause clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" FOO=\\"something\\">
+Acceptance of Delivery. <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> will be deemed to have completed its delivery obligations if in <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/>'s opinion, the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> satisfies the Acceptance Criteria, and <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> notifies <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> in writing that it is accepting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
+
+Inspection and Notice. <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> will have <variable id=\\"businessDays\\" value=\\"10\\"/> Business Days' to inspect and evaluate the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> on the delivery date before notifying <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> that it is either accepting or rejecting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> must meet for the <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> to comply with its requirements and obligations under this agreement, detailed in <variable id=\\"attachment\\" value=\\"%22Attachment%20X%22\\"/>, attached to this agreement.
+\`\`\`"
+`;
+
+exports[`markdown converts acceptance.md to ciceromark 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance of Delivery. ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will be deemed to have completed its delivery obligations if in ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "'s opinion, the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " satisfies the Acceptance Criteria, and ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " notifies ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " in writing that it is accepting the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Inspection and Notice. ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will have ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "businessDays",
+              "value": "10",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " Business Days' to inspect and evaluate the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " on the delivery date before notifying ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " that it is either accepting or rejecting the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " must meet for the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " to comply with its requirements and obligations under this agreement, detailed in ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "attachment",
+              "value": "\\"Attachment X\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", attached to this agreement.",
             },
           ],
         },
@@ -1084,6 +1628,304 @@ Inspection and Notice. <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/>
 
 Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> must meet for the <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> to comply with its requirements and obligations under this agreement, detailed in <variable id=\\"attachment\\" value=\\"%22Attachment%20X%22\\"/>, attached to this agreement.
 ",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts acceptance-notclause2.md to ciceromark 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.CodeBlock",
+      "info": "<clause clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" FOO=\\"something\\">",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "clauseid = \\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" FOO = \\"something\\" ",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "clauseid",
+            "value": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+          },
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "FOO",
+            "value": "something",
+          },
+        ],
+        "closed": false,
+        "content": "",
+        "tagName": "clause",
+      },
+      "text": "Acceptance of Delivery. <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> will be deemed to have completed its delivery obligations if in <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/>'s opinion, the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> satisfies the Acceptance Criteria, and <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> notifies <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> in writing that it is accepting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
+
+Inspection and Notice. <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> will have <variable id=\\"businessDays\\" value=\\"10\\"/> Business Days' to inspect and evaluate the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> on the delivery date before notifying <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> that it is either accepting or rejecting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> must meet for the <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> to comply with its requirements and obligations under this agreement, detailed in <variable id=\\"attachment\\" value=\\"%22Attachment%20X%22\\"/>, attached to this agreement.
+",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts acceptance-notformula.md to ciceromark 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance of Delivery. ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will be deemed to have completed its delivery obligations if in ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "'s opinion, the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " satisfies the Acceptance Criteria, and ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " notifies ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " in writing that it is accepting the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Inspection and Notice. ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "receiver",
+              "value": "\\"Party B\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " will have ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "businessDays",
+              "value": "10",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " Business Days' to inspect and evaluate the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " on the delivery date before notifying ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " that it is either accepting or rejecting the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "deliverable",
+              "value": "\\"Widgets\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " must meet for the ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "shipper",
+              "value": "\\"Party A\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " to comply with its requirements and obligations under this agreement, detailed in ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "attachment",
+              "value": "\\"Attachment X\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", attached to this agreement.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.HtmlInline",
+              "tag": Object {
+                "$class": "org.accordproject.commonmark.TagInfo",
+                "attributeString": "FOO = \\"%22Widgets%22\\" ",
+                "attributes": Array [
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "FOO",
+                    "value": "%22Widgets%22",
+                  },
+                ],
+                "closed": true,
+                "content": "",
+                "tagName": "computed",
+              },
+              "text": "<computed FOO=\\"%22Widgets%22\\"/>",
+            },
+          ],
+        },
+      ],
+      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -2213,6 +3055,202 @@ Object {
 }
 `;
 
+exports[`markdown converts latedelivery-else.md to ciceromark 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "87721b95-7e43-4441-82c7-b4d4db207e6f",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Late Delivery and Penalty.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "In case of delayed delivery",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Conditional",
+              "isTrue": true,
+              "name": "forceMajeure",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": " except for Force Majeure cases,",
+                },
+              ],
+              "whenFalse": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": " even in Force Majeure cases,",
+                },
+              ],
+              "whenTrue": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": " except for Force Majeure cases,",
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "seller",
+              "value": "\\"Dan\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Seller) shall pay to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "buyer",
+              "value": "\\"Steve\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Buyer) for every ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "penaltyDuration",
+              "value": "2 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "of delay penalty amounting to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "penaltyPercentage",
+              "value": "10.5",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "whose delivery has been delayed. Any fractional part of a ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " is to be",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "considered a full ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ". The total amount of penalty shall not however,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "exceed ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "capPercentage",
+              "value": "55.0",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment involved in late delivery.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "If the delay is more than ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "termination",
+              "value": "15 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", the Buyer is entitled to terminate this Contract.",
+            },
+          ],
+        },
+      ],
+      "src": "https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts latedelivery-noforce.md to ciceromark 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
@@ -2287,6 +3325,403 @@ Object {
                   "text": " except for Force Majeure cases,",
                 },
               ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "seller",
+              "value": "\\"Dan\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Seller) shall pay to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "buyer",
+              "value": "\\"Steve\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Buyer) for every ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "penaltyDuration",
+              "value": "2 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "of delay penalty amounting to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "penaltyPercentage",
+              "value": "10.5",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "whose delivery has been delayed. Any fractional part of a ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " is to be",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "considered a full ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ". The total amount of penalty shall not however,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "exceed ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "capPercentage",
+              "value": "55.0",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment involved in late delivery.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "If the delay is more than ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "termination",
+              "value": "15 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", the Buyer is entitled to terminate this Contract.",
+            },
+          ],
+        },
+      ],
+      "src": "https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts latedelivery-notif.md to ciceromark 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "87721b95-7e43-4441-82c7-b4d4db207e6f",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Late Delivery and Penalty.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "In case of delayed delivery",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.HtmlInline",
+              "tag": Object {
+                "$class": "org.accordproject.commonmark.TagInfo",
+                "attributeString": "id = \\"forceMajeure\\" value = \\"%20except%20for%20Force%20Majeure%20cases%2C\\" whenTrue = \\"%20except%20for%20Force%20Majeure%20cases%2C\\" FOO = \\"\\" ",
+                "attributes": Array [
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "id",
+                    "value": "forceMajeure",
+                  },
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "value",
+                    "value": "%20except%20for%20Force%20Majeure%20cases%2C",
+                  },
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "whenTrue",
+                    "value": "%20except%20for%20Force%20Majeure%20cases%2C",
+                  },
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "FOO",
+                    "value": "",
+                  },
+                ],
+                "closed": true,
+                "content": "",
+                "tagName": "if",
+              },
+              "text": "<if id=\\"forceMajeure\\" value=\\"%20except%20for%20Force%20Majeure%20cases%2C\\" whenTrue=\\"%20except%20for%20Force%20Majeure%20cases%2C\\" FOO=\\"\\"/>",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "seller",
+              "value": "\\"Dan\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Seller) shall pay to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "buyer",
+              "value": "\\"Steve\\"",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " (the Buyer) for every ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "penaltyDuration",
+              "value": "2 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "of delay penalty amounting to ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "penaltyPercentage",
+              "value": "10.5",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "whose delivery has been delayed. Any fractional part of a ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": " is to be",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "considered a full ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "fractionalPart",
+              "value": "days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ". The total amount of penalty shall not however,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "exceed ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "capPercentage",
+              "value": "55.0",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "% of the total value of the Equipment involved in late delivery.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "If the delay is more than ",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Variable",
+              "name": "termination",
+              "value": "15 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": ", the Buyer is entitled to terminate this Contract.",
+            },
+          ],
+        },
+      ],
+      "src": "https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts latedelivery-onlyelse.md to ciceromark 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "87721b95-7e43-4441-82c7-b4d4db207e6f",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Late Delivery and Penalty.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "In case of delayed delivery",
+            },
+            Object {
+              "$class": "org.accordproject.ciceromark.Conditional",
+              "isTrue": false,
+              "name": "forceMajeure",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": " even in Force Majeure cases,",
+                },
+              ],
+              "whenFalse": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.Text",
+                  "text": " even in Force Majeure cases,",
+                },
+              ],
+              "whenTrue": Array [],
             },
             Object {
               "$class": "org.accordproject.commonmark.Softbreak",

--- a/packages/markdown-cicero/lib/__snapshots__/CiceroMarkTransformer.test.js.snap
+++ b/packages/markdown-cicero/lib/__snapshots__/CiceroMarkTransformer.test.js.snap
@@ -173,6 +173,93 @@ Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\
 {{/clause}}"
 `;
 
+exports[`acceptance converts acceptance to markdown string (plaintext) 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.",
+            },
+          ],
+        },
+      ],
+      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`acceptance converts acceptance to markdown string (plaintext) 2`] = `
+"HELLO! This is the contract editor.
+
+And below is a clause.
+
+Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".
+
+Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement."
+`;
+
 exports[`acceptance converts acceptance to markdown string (unquoted) 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
@@ -413,96 +500,6 @@ Object {
             Object {
               "$class": "org.accordproject.commonmark.Text",
               "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.",
-            },
-          ],
-        },
-      ],
-      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
-    },
-  ],
-  "xmlns": "http://commonmark.org/xml/1.0",
-}
-`;
-
-exports[`markdown converts acceptance-computed.md to concerto 1`] = `
-Object {
-  "$class": "org.accordproject.commonmark.Document",
-  "nodes": Array [
-    Object {
-      "$class": "org.accordproject.commonmark.Heading",
-      "level": "1",
-      "nodes": Array [
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": "HELLO! This is the contract editor.",
-        },
-      ],
-    },
-    Object {
-      "$class": "org.accordproject.commonmark.Paragraph",
-      "nodes": Array [
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": "And below is a ",
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Strong",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "clause",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Text",
-          "text": ".",
-        },
-      ],
-    },
-    Object {
-      "$class": "org.accordproject.ciceromark.Clause",
-      "name": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
-      "nodes": Array [
-        Object {
-          "$class": "org.accordproject.commonmark.Paragraph",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Paragraph",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Paragraph",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.",
-            },
-          ],
-        },
-        Object {
-          "$class": "org.accordproject.commonmark.Paragraph",
-          "nodes": Array [
-            Object {
-              "$class": "org.accordproject.commonmark.Text",
-              "text": "This is ",
-            },
-            Object {
-              "$class": "org.accordproject.ciceromark.Formula",
-              "dependencies": Array [],
-              "name": "formula",
-              "value": "\\"Widgets\\"",
             },
           ],
         },
@@ -772,6 +769,80 @@ Object {
 }
 `;
 
+exports[`markdown converts acceptance-nosrc.md to concerto 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts acceptance-notclause.md to concerto 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
@@ -841,6 +912,178 @@ Inspection and Notice. <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/>
 
 Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> must meet for the <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> to comply with its requirements and obligations under this agreement, detailed in <variable id=\\"attachment\\" value=\\"%22Attachment%20X%22\\"/>, attached to this agreement.
 ",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts acceptance-notclause2.md to concerto 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.CodeBlock",
+      "info": "<clause clauseid=\\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" FOO=\\"something\\">",
+      "tag": Object {
+        "$class": "org.accordproject.commonmark.TagInfo",
+        "attributeString": "clauseid = \\"479adbb4-dc55-4d1a-ab12-b6c5e16900c0\\" FOO = \\"something\\" ",
+        "attributes": Array [
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "clauseid",
+            "value": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+          },
+          Object {
+            "$class": "org.accordproject.commonmark.Attribute",
+            "name": "FOO",
+            "value": "something",
+          },
+        ],
+        "closed": false,
+        "content": "",
+        "tagName": "clause",
+      },
+      "text": "Acceptance of Delivery. <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> will be deemed to have completed its delivery obligations if in <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/>'s opinion, the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> satisfies the Acceptance Criteria, and <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> notifies <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> in writing that it is accepting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
+
+Inspection and Notice. <variable id=\\"receiver\\" value=\\"%22Party%20B%22\\"/> will have <variable id=\\"businessDays\\" value=\\"10\\"/> Business Days' to inspect and evaluate the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> on the delivery date before notifying <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> that it is either accepting or rejecting the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/>.
+
+Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the <variable id=\\"deliverable\\" value=\\"%22Widgets%22\\"/> must meet for the <variable id=\\"shipper\\" value=\\"%22Party%20A%22\\"/> to comply with its requirements and obligations under this agreement, detailed in <variable id=\\"attachment\\" value=\\"%22Attachment%20X%22\\"/>, attached to this agreement.
+",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts acceptance-notformula.md to concerto 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "479adbb4-dc55-4d1a-ab12-b6c5e16900c0",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance of Delivery. \\"Party A\\" will be deemed to have completed its delivery obligations if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing that it is accepting the \\"Widgets\\".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Inspection and Notice. \\"Party B\\" will have 10 Business Days' to inspect and evaluate the \\"Widgets\\" on the delivery date before notifying \\"Party A\\" that it is either accepting or rejecting the \\"Widgets\\".",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Acceptance Criteria. The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\" must meet for the \\"Party A\\" to comply with its requirements and obligations under this agreement, detailed in \\"Attachment X\\", attached to this agreement.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "This is ",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.HtmlInline",
+              "tag": Object {
+                "$class": "org.accordproject.commonmark.TagInfo",
+                "attributeString": "FOO = \\"%22Widgets%22\\" ",
+                "attributes": Array [
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "FOO",
+                    "value": "%22Widgets%22",
+                  },
+                ],
+                "closed": true,
+                "content": "",
+                "tagName": "computed",
+              },
+              "text": "<computed FOO=\\"%22Widgets%22\\"/>",
+            },
+          ],
+        },
+      ],
+      "src": "ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f",
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -1697,6 +1940,115 @@ Object {
 }
 `;
 
+exports[`markdown converts latedelivery-else.md to concerto 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "87721b95-7e43-4441-82c7-b4d4db207e6f",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Late Delivery and Penalty.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "In case of delayed delivery except for Force Majeure cases,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "\\"Dan\\" (the Seller) shall pay to \\"Steve\\" (the Buyer) for every 2 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "of delay penalty amounting to 10.5% of the total value of the Equipment",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "whose delivery has been delayed. Any fractional part of a days is to be",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "considered a full days. The total amount of penalty shall not however,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "exceed 55.0% of the total value of the Equipment involved in late delivery.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "If the delay is more than 15 days, the Buyer is entitled to terminate this Contract.",
+            },
+          ],
+        },
+      ],
+      "src": "https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts latedelivery-noforce.md to concerto 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
@@ -1753,6 +2105,257 @@ Object {
             Object {
               "$class": "org.accordproject.commonmark.Text",
               "text": "In case of delayed delivery",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "\\"Dan\\" (the Seller) shall pay to \\"Steve\\" (the Buyer) for every 2 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "of delay penalty amounting to 10.5% of the total value of the Equipment",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "whose delivery has been delayed. Any fractional part of a days is to be",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "considered a full days. The total amount of penalty shall not however,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "exceed 55.0% of the total value of the Equipment involved in late delivery.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "If the delay is more than 15 days, the Buyer is entitled to terminate this Contract.",
+            },
+          ],
+        },
+      ],
+      "src": "https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts latedelivery-notif.md to concerto 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "87721b95-7e43-4441-82c7-b4d4db207e6f",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Late Delivery and Penalty.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "In case of delayed delivery",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.HtmlInline",
+              "tag": Object {
+                "$class": "org.accordproject.commonmark.TagInfo",
+                "attributeString": "id = \\"forceMajeure\\" value = \\"%20except%20for%20Force%20Majeure%20cases%2C\\" whenTrue = \\"%20except%20for%20Force%20Majeure%20cases%2C\\" FOO = \\"\\" ",
+                "attributes": Array [
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "id",
+                    "value": "forceMajeure",
+                  },
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "value",
+                    "value": "%20except%20for%20Force%20Majeure%20cases%2C",
+                  },
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "whenTrue",
+                    "value": "%20except%20for%20Force%20Majeure%20cases%2C",
+                  },
+                  Object {
+                    "$class": "org.accordproject.commonmark.Attribute",
+                    "name": "FOO",
+                    "value": "",
+                  },
+                ],
+                "closed": true,
+                "content": "",
+                "tagName": "if",
+              },
+              "text": "<if id=\\"forceMajeure\\" value=\\"%20except%20for%20Force%20Majeure%20cases%2C\\" whenTrue=\\"%20except%20for%20Force%20Majeure%20cases%2C\\" FOO=\\"\\"/>",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "\\"Dan\\" (the Seller) shall pay to \\"Steve\\" (the Buyer) for every 2 days",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "of delay penalty amounting to 10.5% of the total value of the Equipment",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "whose delivery has been delayed. Any fractional part of a days is to be",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "considered a full days. The total amount of penalty shall not however,",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "exceed 55.0% of the total value of the Equipment involved in late delivery.",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Softbreak",
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "If the delay is more than 15 days, the Buyer is entitled to terminate this Contract.",
+            },
+          ],
+        },
+      ],
+      "src": "https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta",
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts latedelivery-onlyelse.md to concerto 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Heading",
+      "level": "1",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "HELLO! This is the contract editor.",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.commonmark.Paragraph",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": "And below is a ",
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Strong",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "clause",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Text",
+          "text": ".",
+        },
+      ],
+    },
+    Object {
+      "$class": "org.accordproject.ciceromark.Clause",
+      "name": "87721b95-7e43-4441-82c7-b4d4db207e6f",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.Heading",
+          "level": "2",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "Late Delivery and Penalty.",
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.Paragraph",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.Text",
+              "text": "In case of delayed delivery even in Force Majeure cases,",
             },
             Object {
               "$class": "org.accordproject.commonmark.Softbreak",

--- a/packages/markdown-cicero/test/data/ciceroedit/acceptance-notclause2.md
+++ b/packages/markdown-cicero/test/data/ciceroedit/acceptance-notclause2.md
@@ -1,0 +1,11 @@
+# HELLO! This is the contract editor. 
+
+And below is a **clause**.
+
+``` <clause clauseid="479adbb4-dc55-4d1a-ab12-b6c5e16900c0" FOO="something">
+Acceptance of Delivery. <variable id="shipper" value="%22Party%20A%22"/> will be deemed to have completed its delivery obligations if in <variable id="receiver" value="%22Party%20B%22"/>'s opinion, the <variable id="deliverable" value="%22Widgets%22"/> satisfies the Acceptance Criteria, and <variable id="receiver" value="%22Party%20B%22"/> notifies <variable id="shipper" value="%22Party%20A%22"/> in writing that it is accepting the <variable id="deliverable" value="%22Widgets%22"/>.
+
+Inspection and Notice. <variable id="receiver" value="%22Party%20B%22"/> will have <variable id="businessDays" value="10"/> Business Days' to inspect and evaluate the <variable id="deliverable" value="%22Widgets%22"/> on the delivery date before notifying <variable id="shipper" value="%22Party%20A%22"/> that it is either accepting or rejecting the <variable id="deliverable" value="%22Widgets%22"/>.
+
+Acceptance Criteria. The "Acceptance Criteria" are the specifications the <variable id="deliverable" value="%22Widgets%22"/> must meet for the <variable id="shipper" value="%22Party%20A%22"/> to comply with its requirements and obligations under this agreement, detailed in <variable id="attachment" value="%22Attachment%20X%22"/>, attached to this agreement.
+```

--- a/packages/markdown-cicero/test/data/ciceroedit/acceptance-notformula.md
+++ b/packages/markdown-cicero/test/data/ciceroedit/acceptance-notformula.md
@@ -2,12 +2,12 @@
 
 And below is a **clause**.
 
-``` <clause src="ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f" clauseid="479adbb4-dc55-4d1a-ab12-b6c5e16900c0">
+``` <clause clauseid="479adbb4-dc55-4d1a-ab12-b6c5e16900c0" src="ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f">
 Acceptance of Delivery. <variable id="shipper" value="%22Party%20A%22"/> will be deemed to have completed its delivery obligations if in <variable id="receiver" value="%22Party%20B%22"/>'s opinion, the <variable id="deliverable" value="%22Widgets%22"/> satisfies the Acceptance Criteria, and <variable id="receiver" value="%22Party%20B%22"/> notifies <variable id="shipper" value="%22Party%20A%22"/> in writing that it is accepting the <variable id="deliverable" value="%22Widgets%22"/>.
 
 Inspection and Notice. <variable id="receiver" value="%22Party%20B%22"/> will have <variable id="businessDays" value="10"/> Business Days' to inspect and evaluate the <variable id="deliverable" value="%22Widgets%22"/> on the delivery date before notifying <variable id="shipper" value="%22Party%20A%22"/> that it is either accepting or rejecting the <variable id="deliverable" value="%22Widgets%22"/>.
 
 Acceptance Criteria. The "Acceptance Criteria" are the specifications the <variable id="deliverable" value="%22Widgets%22"/> must meet for the <variable id="shipper" value="%22Party%20A%22"/> to comply with its requirements and obligations under this agreement, detailed in <variable id="attachment" value="%22Attachment%20X%22"/>, attached to this agreement.
 
-This is <computed value="%22Widgets%22"/>
+This is <computed FOO="%22Widgets%22"/>
 ```

--- a/packages/markdown-cicero/test/data/ciceroedit/latedelivery-else.md
+++ b/packages/markdown-cicero/test/data/ciceroedit/latedelivery-else.md
@@ -1,0 +1,16 @@
+# HELLO! This is the contract editor. 
+
+And below is a **clause**.
+
+``` <clause src="https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta" clauseid="87721b95-7e43-4441-82c7-b4d4db207e6f">
+Late Delivery and Penalty.
+----
+
+In case of delayed delivery<if id="forceMajeure" value="%20except%20for%20Force%20Majeure%20cases%2C" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" whenFalse="%20even%20in%20Force%20Majeure%20cases%2C"/>
+<variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
+of delay penalty amounting to <variable id="penaltyPercentage" value="10.5"/>% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a <variable id="fractionalPart" value="days"/> is to be
+considered a full <variable id="fractionalPart" value="days"/>. The total amount of penalty shall not however,
+exceed <variable id="capPercentage" value="55.0"/>% of the total value of the Equipment involved in late delivery.
+If the delay is more than <variable id="termination" value="15%20days"/>, the Buyer is entitled to terminate this Contract.
+```

--- a/packages/markdown-cicero/test/data/ciceroedit/latedelivery-notif.md
+++ b/packages/markdown-cicero/test/data/ciceroedit/latedelivery-notif.md
@@ -1,0 +1,16 @@
+# HELLO! This is the contract editor. 
+
+And below is a **clause**.
+
+``` <clause src="https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta" clauseid="87721b95-7e43-4441-82c7-b4d4db207e6f">
+Late Delivery and Penalty.
+----
+
+In case of delayed delivery<if id="forceMajeure" value="%20except%20for%20Force%20Majeure%20cases%2C" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" FOO=""/>
+<variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
+of delay penalty amounting to <variable id="penaltyPercentage" value="10.5"/>% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a <variable id="fractionalPart" value="days"/> is to be
+considered a full <variable id="fractionalPart" value="days"/>. The total amount of penalty shall not however,
+exceed <variable id="capPercentage" value="55.0"/>% of the total value of the Equipment involved in late delivery.
+If the delay is more than <variable id="termination" value="15%20days"/>, the Buyer is entitled to terminate this Contract.
+```

--- a/packages/markdown-cicero/test/data/ciceroedit/latedelivery-onlyelse.md
+++ b/packages/markdown-cicero/test/data/ciceroedit/latedelivery-onlyelse.md
@@ -1,0 +1,16 @@
+# HELLO! This is the contract editor. 
+
+And below is a **clause**.
+
+``` <clause src="https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta" clauseid="87721b95-7e43-4441-82c7-b4d4db207e6f">
+Late Delivery and Penalty.
+----
+
+In case of delayed delivery<if id="forceMajeure" value="%20even%20in%20Force%20Majeure%20cases%2C" whenTrue="" whenFalse="%20even%20in%20Force%20Majeure%20cases%2C"/>
+<variable id="seller" value="%22Dan%22"/> (the Seller) shall pay to <variable id="buyer" value="%22Steve%22"/> (the Buyer) for every <variable id="penaltyDuration" value="2%20days"/>
+of delay penalty amounting to <variable id="penaltyPercentage" value="10.5"/>% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a <variable id="fractionalPart" value="days"/> is to be
+considered a full <variable id="fractionalPart" value="days"/>. The total amount of penalty shall not however,
+exceed <variable id="capPercentage" value="55.0"/>% of the total value of the Equipment involved in late delivery.
+If the delay is more than <variable id="termination" value="15%20days"/>, the Buyer is entitled to terminate this Contract.
+```

--- a/packages/markdown-cicero/test/data/ciceromark/acceptance-nosrc.md
+++ b/packages/markdown-cicero/test/data/ciceromark/acceptance-nosrc.md
@@ -2,12 +2,10 @@
 
 And below is a **clause**.
 
-{{#clause 479adbb4-dc55-4d1a-ab12-b6c5e16900c0 src="ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f"}}
+{{#clause 479adbb4-dc55-4d1a-ab12-b6c5e16900c0}}
 Acceptance of Delivery. "Party A" will be deemed to have completed its delivery obligations if in "Party B"'s opinion, the "Widgets" satisfies the Acceptance Criteria, and "Party B" notifies "Party A" in writing that it is accepting the "Widgets".
 
 Inspection and Notice. "Party B" will have 10 Business Days' to inspect and evaluate the "Widgets" on the delivery date before notifying "Party A" that it is either accepting or rejecting the "Widgets".
 
 Acceptance Criteria. The "Acceptance Criteria" are the specifications the "Widgets" must meet for the "Party A" to comply with its requirements and obligations under this agreement, detailed in "Attachment X", attached to this agreement.
-
-This is {{%"Widgets"%}}
 {{/clause}}

--- a/packages/markdown-cicero/test/data/ciceromark/acceptance-notclause2.md
+++ b/packages/markdown-cicero/test/data/ciceromark/acceptance-notclause2.md
@@ -1,0 +1,12 @@
+HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+``` <clause clauseid="479adbb4-dc55-4d1a-ab12-b6c5e16900c0" FOO="something">
+Acceptance of Delivery. <variable id="shipper" value="%22Party%20A%22"/> will be deemed to have completed its delivery obligations if in <variable id="receiver" value="%22Party%20B%22"/>'s opinion, the <variable id="deliverable" value="%22Widgets%22"/> satisfies the Acceptance Criteria, and <variable id="receiver" value="%22Party%20B%22"/> notifies <variable id="shipper" value="%22Party%20A%22"/> in writing that it is accepting the <variable id="deliverable" value="%22Widgets%22"/>.
+
+Inspection and Notice. <variable id="receiver" value="%22Party%20B%22"/> will have <variable id="businessDays" value="10"/> Business Days' to inspect and evaluate the <variable id="deliverable" value="%22Widgets%22"/> on the delivery date before notifying <variable id="shipper" value="%22Party%20A%22"/> that it is either accepting or rejecting the <variable id="deliverable" value="%22Widgets%22"/>.
+
+Acceptance Criteria. The "Acceptance Criteria" are the specifications the <variable id="deliverable" value="%22Widgets%22"/> must meet for the <variable id="shipper" value="%22Party%20A%22"/> to comply with its requirements and obligations under this agreement, detailed in <variable id="attachment" value="%22Attachment%20X%22"/>, attached to this agreement.
+```

--- a/packages/markdown-cicero/test/data/ciceromark/acceptance-notformula.md
+++ b/packages/markdown-cicero/test/data/ciceromark/acceptance-notformula.md
@@ -1,0 +1,14 @@
+HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+{{#clause 479adbb4-dc55-4d1a-ab12-b6c5e16900c0 src="ap://acceptance-of-delivery@0.12.1#721d1aa0999a5d278653e211ae2a64b75fdd8ca6fa1f34255533c942404c5c1f"}}
+Acceptance of Delivery. "Party A" will be deemed to have completed its delivery obligations if in "Party B"'s opinion, the "Widgets" satisfies the Acceptance Criteria, and "Party B" notifies "Party A" in writing that it is accepting the "Widgets".
+
+Inspection and Notice. "Party B" will have 10 Business Days' to inspect and evaluate the "Widgets" on the delivery date before notifying "Party A" that it is either accepting or rejecting the "Widgets".
+
+Acceptance Criteria. The "Acceptance Criteria" are the specifications the "Widgets" must meet for the "Party A" to comply with its requirements and obligations under this agreement, detailed in "Attachment X", attached to this agreement.
+
+This is <computed FOO="%22Widgets%22"/>
+{{/clause}}

--- a/packages/markdown-cicero/test/data/ciceromark/latedelivery-else.md
+++ b/packages/markdown-cicero/test/data/ciceromark/latedelivery-else.md
@@ -1,0 +1,17 @@
+HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+{{#clause 87721b95-7e43-4441-82c7-b4d4db207e6f src="https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta"}}
+Late Delivery and Penalty.
+----
+
+In case of delayed delivery except for Force Majeure cases,
+"Dan" (the Seller) shall pay to "Steve" (the Buyer) for every 2 days
+of delay penalty amounting to 10.5% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a days is to be
+considered a full days. The total amount of penalty shall not however,
+exceed 55.0% of the total value of the Equipment involved in late delivery.
+If the delay is more than 15 days, the Buyer is entitled to terminate this Contract.
+{{/clause}}

--- a/packages/markdown-cicero/test/data/ciceromark/latedelivery-notif.md
+++ b/packages/markdown-cicero/test/data/ciceromark/latedelivery-notif.md
@@ -1,0 +1,17 @@
+HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+{{#clause 87721b95-7e43-4441-82c7-b4d4db207e6f src="https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta"}}
+Late Delivery and Penalty.
+----
+
+In case of delayed delivery<if id="forceMajeure" value="%20except%20for%20Force%20Majeure%20cases%2C" whenTrue="%20except%20for%20Force%20Majeure%20cases%2C" FOO=""/>
+"Dan" (the Seller) shall pay to "Steve" (the Buyer) for every 2 days
+of delay penalty amounting to 10.5% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a days is to be
+considered a full days. The total amount of penalty shall not however,
+exceed 55.0% of the total value of the Equipment involved in late delivery.
+If the delay is more than 15 days, the Buyer is entitled to terminate this Contract.
+{{/clause}}

--- a/packages/markdown-cicero/test/data/ciceromark/latedelivery-onlyelse.md
+++ b/packages/markdown-cicero/test/data/ciceromark/latedelivery-onlyelse.md
@@ -1,0 +1,17 @@
+HELLO! This is the contract editor.
+====
+
+And below is a **clause**.
+
+{{#clause 87721b95-7e43-4441-82c7-b4d4db207e6f src="https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta"}}
+Late Delivery and Penalty.
+----
+
+In case of delayed delivery even in Force Majeure cases,
+"Dan" (the Seller) shall pay to "Steve" (the Buyer) for every 2 days
+of delay penalty amounting to 10.5% of the total value of the Equipment
+whose delivery has been delayed. Any fractional part of a days is to be
+considered a full days. The total amount of penalty shall not however,
+exceed 55.0% of the total value of the Equipment involved in late delivery.
+If the delay is more than 15 days, the Buyer is entitled to terminate this Contract.
+{{/clause}}


### PR DESCRIPTION
### Changes
- Remove now unnecessary codeblock text processing function
- Improves code coverage, notably for ciceroedit transform
- rename `quoteVariables` option to `unquoteVariables`, more consistent with `removeFormatting`
- clean up implementation of `unquoteVariables`
