### PR TITLE
Post 0.12 release fixes: HTML rendering and toMarkdownCicero for Slate transform

### DIFF
--- a/packages/markdown-it-cicero/lib/index.js
+++ b/packages/markdown-it-cicero/lib/index.js
@@ -18,9 +18,14 @@ const cicero_inline = require('./cicero_inline');
 const cicero_block = require('./cicero_block');
 const cicero_block_render = require('./cicero_block_render');
 
-// Regexps to match cicero elements
+const formula_inline = function (tokens, idx /*, options, env */) {
+  const token = tokens[idx];
+  return `<span class="formula">${token.content}</span>`;
+};
 
 function cicero_plugin(md) {
+    md.renderer.rules['formula'] = formula_inline;
+
     md.inline.ruler.before('emphasis', 'cicero', cicero_inline);
 
     md.block.ruler.before('fence', 'cicero_block', cicero_block, {

--- a/packages/markdown-it-cicero/test/data/all.html
+++ b/packages/markdown-it-cicero/test/data/all.html
@@ -1,5 +1,5 @@
 <h1>Title</h1>
-<p>Paragraph with a &quot;seller&quot; and more text and, this is conditional, with some <strong>marker</strong> <formula name="formula">.</p>
+<p>Paragraph with a &quot;seller&quot; and more text and, this is conditional, with some <strong>marker</strong> <span class="formula"> 1+1 = 3 </span>.</p>
 <div name="payment" src="ap://promissory-note-md@0.3.2#b4c966c2081303d017d3dde359bd8039ceb4a5dbacb6e6e09618e33a00d3f566" class="clause_block">
 <p>BLABLABLABLA</p>
 <ul>
@@ -8,4 +8,4 @@
 <li>three</li>
 </ul>
 </div>
-<p>This is a <a href="mylink">link with a <formula name="formula"> in it</a>.</p>
+<p>This is a <a href="mylink">link with a <span class="formula"> formula </span> in it</a>.</p>

--- a/packages/markdown-it-template/lib/index.js
+++ b/packages/markdown-it-template/lib/index.js
@@ -19,7 +19,38 @@ const template_inline_render = require('./template_inline_render');
 const template_block = require('./template_block');
 const template_block_render = require('./template_block_render');
 
-// Regexps to match template elements
+/**
+ * Get an attribute value
+ *
+ * @param {*} attrs open ordered list attributes
+ * @param {string} name attribute name
+ * @param {*} def a default value
+ * @returns {string} the initial index
+ */
+function getAttr(attrs,name,def) {
+    const startAttrs = attrs.filter((x) => x[0] === name);
+    if (startAttrs[0]) {
+        return '' + startAttrs[0][1];
+    } else {
+        return def;
+    }
+}
+
+const variable_inline = function (tokens, idx /*, options, env */) {
+  const token = tokens[idx];
+  const name = getAttr(token.attrs,'name',null);
+  const format = getAttr(token.attrs,'format',null);
+  let attrs = `name="${name}"`;
+  if(format) {
+    attrs += ` format="${format}"`;
+  }
+  return `<span class="variable" ${attrs}>${name}</span>`;
+};
+
+const formula_inline = function (tokens, idx /*, options, env */) {
+  const token = tokens[idx];
+  return `<span class="formula">${token.content}</span>`;
+};
 
 function template_plugin(md) {
     md.inline.ruler.before('emphasis', 'template', template_inline);
@@ -31,6 +62,8 @@ function template_plugin(md) {
     md.renderer.rules['inline_block_with_close'] = template_inline_render('with');
     md.renderer.rules['inline_block_join_open'] = template_inline_render('join');
     md.renderer.rules['inline_block_join_close'] = template_inline_render('join');
+    md.renderer.rules['variable'] = variable_inline;
+    md.renderer.rules['formula'] = formula_inline;
 
     md.block.ruler.before('fence', 'template_block', template_block, {
         alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]

--- a/packages/markdown-it-template/test/data/all.html
+++ b/packages/markdown-it-template/test/data/all.html
@@ -1,14 +1,14 @@
 <h1>Title</h1>
-<p>Paragraph with a <variable name="seller"> and more text and<div name="forceMajeure" class="if_inline">, this is conditional,</div> with some <strong>marker</strong> <formula>. <div name="foo" separator=";" class="join_inline"><variable name="element"></div></p>
-<p>Paragraph with a <variable name="seller"> and more text and<div name="forceMajeure" class="if_inline">, this is conditional,<else> and this is too,</div> with some <strong>marker</strong> <formula>. <div name="foo" class="join_inline"><variable name="element"></div></p>
-<p><variable name="buyer" format="FOO"></p>
+<p>Paragraph with a <span class="variable" name="seller">seller</span> and more text and<div name="forceMajeure" class="if_inline">, this is conditional,</div> with some <strong>marker</strong> <span class="formula"> 1+1 = 3 </span>. <div name="foo" separator=";" class="join_inline"><span class="variable" name="element">element</span></div></p>
+<p>Paragraph with a <span class="variable" name="seller">seller</span> and more text and<div name="forceMajeure" class="if_inline">, this is conditional,<else> and this is too,</div> with some <strong>marker</strong> <span class="formula"> 1+1 = 3 </span>. <div name="foo" class="join_inline"><span class="variable" name="element">element</span></div></p>
+<p><span class="variable" name="buyer" format="FOO">buyer</span></p>
 <div name="payment" src="ap://promissory-note-md@0.3.2#b4c966c2081303d017d3dde359bd8039ceb4a5dbacb6e6e09618e33a00d3f566" class="clause_block">
 <p>BLABLABLABLA</p>
 <div name="items" class="ulist_block">
-<p>one item: <strong><variable name="item"></strong></p>
+<p>one item: <strong><span class="variable" name="item">item</span></strong></p>
 </div>
 <div name="items" class="olist_block">
-<p>one item: <strong><variable name="item"></strong></p>
+<p>one item: <strong><span class="variable" name="item">item</span></strong></p>
 </div>
 <ul>
 <li>one</li>
@@ -18,10 +18,10 @@
 </div>
 <p>There is also a new <div name="name" class="optional_inline"> inline which can contain <this></div>.</p>
 <p>There is also a new <div name="name" class="optional_inline"> inline which can contain <this><else>something else</div>.</p>
-<p>This is a <a href="mylink">link with a <variable name="variable"> in it</a>.</p>
+<p>This is a <a href="mylink">link with a <span class="variable" name="variable">variable</span> in it</a>.</p>
 <p>This is a <a href="mylink">link with a <this> in it</a>.</p>
 <p>This is a <a href="mylink">link with an <else> in it</a>.</p>
 <p>This is a <a href="mylink">link with an <div name="name" class="if_inline"> in it</div></a>.</p>
 <p>This is a <a href="mylink">link with an <div name="name" class="optional_inline"> in it</div></a>.</p>
 <p>This is a <a href="mylink">link with a <div name="name" class="join_inline"> in it</div></a>.</p>
-<p>This is a <a href="mylink">link with a <formula> in it</a>.</p>
+<p>This is a <a href="mylink">link with a <span class="formula"> formula </span> in it</a>.</p>

--- a/packages/markdown-it-template/test/data/autoclose1.html
+++ b/packages/markdown-it-template/test/data/autoclose1.html
@@ -1,7 +1,7 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <blockquote>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.</p>
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.</p>
 </div>
 </blockquote>
 <p>{{/clause}}</p>

--- a/packages/markdown-it-template/test/data/autoclose2.html
+++ b/packages/markdown-it-template/test/data/autoclose2.html
@@ -1,6 +1,6 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.
 {{/clause}}</p>
 <p>General.</p>
 </div>

--- a/packages/markdown-it-template/test/data/autoclose3.html
+++ b/packages/markdown-it-template/test/data/autoclose3.html
@@ -1,6 +1,6 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.
 {{/clause}}      x</p>
 <p>General.</p>
 </div>

--- a/packages/markdown-it-template/test/data/clause1.html
+++ b/packages/markdown-it-template/test/data/clause1.html
@@ -1,5 +1,5 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.</p>
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.</p>
 </div>
 <p>General.</p>

--- a/packages/markdown-it-template/test/data/clause2.html
+++ b/packages/markdown-it-template/test/data/clause2.html
@@ -1,7 +1,7 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <blockquote>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.</p>
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.</p>
 </div>
 </blockquote>
 <p>General.</p>

--- a/packages/markdown-it-template/test/data/clause3.html
+++ b/packages/markdown-it-template/test/data/clause3.html
@@ -1,7 +1,7 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <blockquote>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.</p>
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.</p>
 </div>
 </blockquote>
 <p>General.</p>

--- a/packages/markdown-it-template/test/data/clause4.html
+++ b/packages/markdown-it-template/test/data/clause4.html
@@ -1,6 +1,6 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.
 {{/}}</p>
 </div>
 <p>General.</p>

--- a/packages/markdown-it-template/test/data/clause5.html
+++ b/packages/markdown-it-template/test/data/clause5.html
@@ -1,5 +1,5 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.</p>
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.</p>
 </div>
 <p>General.</p>

--- a/packages/markdown-it-template/test/data/clause6.html
+++ b/packages/markdown-it-template/test/data/clause6.html
@@ -1,6 +1,6 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <div name="payment" class="clause_block">
-<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.
+<p>Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.
 {{#ulist}}</p>
 </div>
 <p>{{/ulist}}</p>

--- a/packages/markdown-it-template/test/data/none.html
+++ b/packages/markdown-it-template/test/data/none.html
@@ -1,14 +1,14 @@
 <h1>Title</h1>
 <p>Paragraph with a {seller}} and more text and<div name="forceMajeure" class="if_inline">, this is optional,</div> with some <strong>marker</strong> {{% % 1+1 = 3 %}}.</p>
-<p><variable name="buyer" format="FOO"></p>
+<p><span class="variable" name="buyer" format="FOO">buyer</span></p>
 <p>{#clause payment}}
 BLABLABLABLA</p>
 <p>{{ulist items}}
-one item: <strong><variable name="item"></strong>
+one item: <strong><span class="variable" name="item">item</span></strong>
 {{/ulist}}</p>
 <div name="items" class="olist_block">
-<p>one item: <strong><variable name="item"></strong>
-<variable name="olist"></p>
+<p>one item: <strong><span class="variable" name="item">item</span></strong>
+<span class="variable" name="olist">olist</span></p>
 <ul>
 <li>one</li>
 <li>two</li>

--- a/packages/markdown-it-template/test/data/notclause1.html
+++ b/packages/markdown-it-template/test/data/notclause1.html
@@ -1,5 +1,5 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <p>{{#}}
-Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.
+Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.
 {{/clause}}</p>
 <p>General.</p>

--- a/packages/markdown-it-template/test/data/notclause2.html
+++ b/packages/markdown-it-template/test/data/notclause2.html
@@ -1,5 +1,5 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <p>{{#clause}}
-Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.
+Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.
 {{/clause}}</p>
 <p>General.</p>

--- a/packages/markdown-it-template/test/data/notclause3.html
+++ b/packages/markdown-it-template/test/data/notclause3.html
@@ -1,5 +1,5 @@
 <p>Copyright Notices. Licensee shall ensure that its use of the Work is marked with the appropriate copyright notices specified by Licensor in a reasonably prominent position in the order and manner provided by Licensor. Licensee shall abide by the copyright laws and what are considered to be sound practices for copyright notice provisions in the Territory. Licensee shall not use any copyright notices that conflict with, confuse, or negate the notices Licensor provides and requires hereunder.</p>
 <p>{{#claus foo}}
-Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <variable name="amountText"> (<variable name="amount">) upon execution of this Agreement, payable as follows: <variable name="paymentProcedure">.
+Payment. As consideration in full for the rights granted herein, Licensee shall pay Licensor a one-time fee in the amount of <span class="variable" name="amountText">amountText</span> (<span class="variable" name="amount">amount</span>) upon execution of this Agreement, payable as follows: <span class="variable" name="paymentProcedure">paymentProcedure</span>.
 {{/clause}}</p>
 <p>General.</p>

--- a/packages/markdown-slate/lib/SlateTransformer.js
+++ b/packages/markdown-slate/lib/SlateTransformer.js
@@ -109,6 +109,18 @@ class SlateTransformer {
     }
 
     /**
+     * Converts a Slate JSON to a markdown cicero string
+     * @param {*} value - Slate json
+     * @param {object} [options] - configuration options
+     * @returns {*} markdown cicero string
+     */
+    toMarkdownCicero(value, options) {
+        const ciceroMark = this.toCiceroMark(value);
+        const ciceroMarkUnwrapped = this.ciceroMarkTransformer.toCiceroMarkUnwrapped(ciceroMark, options);
+        return this.ciceroMarkTransformer.toMarkdownCicero(ciceroMarkUnwrapped, options);
+    }
+
+    /**
      * Converts a markdown string to a Slate JSON
      * @param {string} markdown - a markdown string
      * @returns {*} Slate json

--- a/packages/markdown-slate/lib/SlateTransformer.test.js
+++ b/packages/markdown-slate/lib/SlateTransformer.test.js
@@ -23,6 +23,17 @@ let slateTransformer = null;
 /* eslint-disable no-undef */
 // @ts-nocheck
 
+/**
+ * Prepare the text for parsing (normalizes new lines, etc)
+ * @param {string} input - the text for the clause
+ * @return {string} - the normalized text for the clause
+ */
+function normalizeNLs(input) {
+    // we replace all \r and \n with \n
+    let text =  input.replace(/\r/gm,'');
+    return text;
+}
+
 // @ts-ignore
 // eslint-disable-next-line no-undef
 beforeAll(() => {
@@ -128,5 +139,21 @@ describe('ciceromark <-> slate', () => {
             // check roundtrip
             expect(expectedSlateValue).toEqual(value);
         });
+    });
+});
+
+describe('slate -> markdown_cicero', () => {
+    it('converts acceptance from slate to markdown cicero', () => {
+        // load slate DOM
+        const slateDom = JSON.parse(fs.readFileSync(__dirname + '/../test/data/ciceromark/acceptance_slate.json', 'utf8'));
+        // load expected markdown cicero
+        const expectedMarkdownCicero = normalizeNLs(fs.readFileSync(__dirname + '/../test/data/ciceromark/acceptance.md', 'utf8'));
+
+        // convert the slate to markdown cicero and compare
+        const actualMarkdownCicero = slateTransformer.toMarkdownCicero(slateDom);
+        expect(actualMarkdownCicero).toMatchSnapshot(); // (3)
+
+        // check roundtrip
+        expect(actualMarkdownCicero).toEqual(expectedMarkdownCicero);
     });
 });

--- a/packages/markdown-slate/lib/__snapshots__/SlateTransformer.test.js.snap
+++ b/packages/markdown-slate/lib/__snapshots__/SlateTransformer.test.js.snap
@@ -6084,3 +6084,38 @@ Object {
   "xmlns": "http://commonmark.org/xml/1.0",
 }
 `;
+
+exports[`slate -> markdown_cicero converts acceptance from slate to markdown cicero 1`] = `
+"Heading
+====
+
+And below is a **clause**.
+
+{{#clause deliveryClause}}
+Acceptance of Delivery.
+----
+
+\\"Party A\\" will be deemed to have completed its delivery obligations
+if in \\"Party B\\"'s opinion, the \\"Widgets\\" satisfies the
+Acceptance Criteria, and \\"Party B\\" notifies \\"Party A\\" in writing
+that it is accepting the \\"Widgets\\".
+
+Inspection and Notice.
+----
+
+\\"Party B\\" will have 10 Business Days to inspect and
+evaluate the \\"Widgets\\" on the delivery date before notifying
+\\"Party A\\" that it is either accepting or rejecting the
+\\"Widgets\\".
+
+Acceptance Criteria.
+----
+
+The \\"Acceptance Criteria\\" are the specifications the \\"Widgets\\"
+must meet for the \\"Party A\\" to comply with its requirements and
+obligations under this agreement, detailed in \\"Attachment X\\", attached
+to this agreement.
+{{/clause}}
+
+More text"
+`;

--- a/packages/markdown-slate/test/data/ciceromark/acceptance.md
+++ b/packages/markdown-slate/test/data/ciceromark/acceptance.md
@@ -1,0 +1,32 @@
+Heading
+====
+
+And below is a **clause**.
+
+{{#clause deliveryClause}}
+Acceptance of Delivery.
+----
+
+"Party A" will be deemed to have completed its delivery obligations
+if in "Party B"'s opinion, the "Widgets" satisfies the
+Acceptance Criteria, and "Party B" notifies "Party A" in writing
+that it is accepting the "Widgets".
+
+Inspection and Notice.
+----
+
+"Party B" will have 10 Business Days to inspect and
+evaluate the "Widgets" on the delivery date before notifying
+"Party A" that it is either accepting or rejecting the
+"Widgets".
+
+Acceptance Criteria.
+----
+
+The "Acceptance Criteria" are the specifications the "Widgets"
+must meet for the "Party A" to comply with its requirements and
+obligations under this agreement, detailed in "Attachment X", attached
+to this agreement.
+{{/clause}}
+
+More text


### PR DESCRIPTION
# Issue #270 & new Slate API call
- Better native render for markdown-it plugins.
- new `SlateTransformer.toMarkdownCicero` call for convenience
