### PR TITLE
Critical bug fix for parser rebuilding + handling of {{this}} in templatemark plugin rendering

### DIFF
--- a/packages/markdown-it-template/lib/index.js
+++ b/packages/markdown-it-template/lib/index.js
@@ -47,6 +47,10 @@ const variable_inline = function (tokens, idx /*, options, env */) {
   return `<span class="variable" ${attrs}>${name}</span>`;
 };
 
+const this_inline = function (tokens, idx /*, options, env */) {
+  return `<span class="variable" name="this">this</span>`;
+};
+
 const else_inline = function (tokens, idx /*, options, env */) {
   return `</span><span class="else_inline">`;
 };
@@ -68,6 +72,7 @@ function template_plugin(md) {
     md.renderer.rules['inline_block_join_close'] = template_inline_render('join');
     md.renderer.rules['inline_block_else'] = else_inline;
     md.renderer.rules['variable'] = variable_inline;
+    md.renderer.rules['this'] = this_inline;
     md.renderer.rules['formula'] = formula_inline;
 
     md.block.ruler.before('fence', 'template_block', template_block, {

--- a/packages/markdown-it-template/test/data/all.html
+++ b/packages/markdown-it-template/test/data/all.html
@@ -16,10 +16,10 @@
 <li>three</li>
 </ul>
 </div>
-<p>There is also a new <span name="name" class="optional_inline"> inline which can contain <this></span>.</p>
-<p>There is also a new <span name="name" class="optional_inline"> inline which can contain <this></span><span class="else_inline">something else</span>.</p>
+<p>There is also a new <span name="name" class="optional_inline"> inline which can contain <span class="variable" name="this">this</span></span>.</p>
+<p>There is also a new <span name="name" class="optional_inline"> inline which can contain <span class="variable" name="this">this</span></span><span class="else_inline">something else</span>.</p>
 <p>This is a <a href="mylink">link with a <span class="variable" name="variable">variable</span> in it</a>.</p>
-<p>This is a <a href="mylink">link with a <this> in it</a>.</p>
+<p>This is a <a href="mylink">link with a <span class="variable" name="this">this</span> in it</a>.</p>
 <p>This is a <a href="mylink">link with an <span name="name" class="if_inline"> in it</span></a>.</p>
 <p>This is a <a href="mylink">link with an <span name="name" class="optional_inline"> in it</span></a>.</p>
 <p>This is a <a href="mylink">link with a <span name="name" class="join_inline"> in it</span></a>.</p>

--- a/packages/markdown-template/test/parsermanager.js
+++ b/packages/markdown-template/test/parsermanager.js
@@ -50,6 +50,20 @@ describe('#constructor', () => {
         should.exist(parserManager.getTemplateMark());
     });
 
+    it('rebuild a parser', async () => {
+        const model = './test/data/helloworld/model.cto';
+        const template = normalizeNLs(fs.readFileSync('./test/data/helloworld/grammar.tem.md', 'utf8'));
+        const modelManager = await ModelLoader.loadModelManager(null,[model]);
+        const parserManager = new ParserManager(modelManager,'clause',null,null);
+        parserManager.setTemplate(template);
+        parserManager.getTemplate().should.equal('Name of the person to greet: {{name}}.\nThank you!');
+        (() => parserManager.getTemplateMark()).should.throw('Must call buildParser before calling getTemplateMark');
+        (() => parserManager.getParser()).should.throw('Must call buildParser before calling getParser');
+        parserManager.buildParser();
+        parserManager.buildParser();
+        should.exist(parserManager.getTemplateMark());
+    });
+
     it('handle formulas', async () => {
         const model = './test/data/fixed-interests/model.cto';
         const template = normalizeNLs(fs.readFileSync('./test/data/fixed-interests/grammar.tem.md', 'utf8'));


### PR DESCRIPTION
# Issue #277 + {{this}}

### Changes
-  #277 More robust API for building and rebuilding the parser
- New special variable `{{this}}` rendered as `<span class="variable" name="this">this</span>`

### Flags
- This change is actually making sense, since the parsing table serves both as the external description (i.e., declarative mapping from types to parsers) and internally is annotated by (possibly recursive) javascript functions when building the parser.
