### PR TITLE
fix(template) Proper parse exception for inconsistant variables

### DIFF
--- a/packages/markdown-template/lib/TemplateMarkTransformer.js
+++ b/packages/markdown-template/lib/TemplateMarkTransformer.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-const { ParseException } = require('@accordproject/concerto-core');
+const _throwParseException = require('./errorutil')._throwParseException;
 const {
     templateMarkManager,
     templateToTokens,
@@ -28,65 +28,6 @@ const normalizeToMarkdownCicero = require('./normalize').normalizeToMarkdownCice
 const normalizeFromMarkdownCicero = require('./normalize').normalizeFromMarkdownCicero;
 
 const ToCiceroMarkVisitor = require('./ToCiceroMarkVisitor');
-
-/**
- * Minimum length of expected token
- * @param {object} expected the expected token
- * @return {number} the minimum length
- */
-function maxOfExpected(expected) {
-    return Math.max.apply(null,expected.map((x) => x.length));
-}
-
-/**
- * Clean up expected tokens
- * @param {object} expected the expected token
- * @return {object} nicer looking expected tokens
- */
-function cleanExpected(expected) {
-    return expected.map((x) => new RegExp(/'[^']*'/).test(x) ? x.substr(1,x.length -2) : x);
-}
-
-/**
- * Throw a parse exception
- * @param {string} markdown a markdown string
- * @param {object} result the parsing failure
- * @param {string} [fileName] - the fileName for the markdown (optional)
- */
-function _throwParseError(markdown,result,fileName) {
-    // File location
-    const fileLocation = {};
-    const start = result.index;
-    const end = Object.assign({},start);
-    end.offset = end.offset+1;
-    end.column = end.column+1;
-    fileLocation.start = start;
-    fileLocation.end = end;
-
-    // Short message
-    const shortMessage = `Parse error at line ${result.index.line} column ${result.index.column}`;
-
-    // Long message
-    const lines = markdown.split('\n');
-    const expected = result.expected;
-    const underline = ((line) => {
-        const maxLength = line.length - (start.column-1);
-        const maxExpected = maxOfExpected(cleanExpected(expected));
-        return '^'.repeat(maxLength < maxExpected ? maxLength : maxExpected);
-    });
-    const line = lines[start.line - 1];
-    const snippet = line + '\n' + ' '.repeat(start.column-1) + underline(line);
-    const isEOF = (x) => {
-        if (x[0] && x[0] === 'EOF') {
-            return true;
-        } else {
-            return false;
-        }
-    };
-    const expectedMessage = 'Expected: ' + (isEOF(expected) ? 'End of text' : expected.join(' or '));
-    const longMessage = shortMessage + '\n' + snippet + '\n' + expectedMessage;
-    throw new ParseException(shortMessage, fileLocation, fileName, longMessage, 'markdown-template');
-}
 
 /**
  * Support for CiceroMark Templates
@@ -171,11 +112,16 @@ class TemplateMarkTransformer {
         const markdownFileName = input.fileName;
 
         // Parse the markdown
-        let result = parser.parse(markdown);
+        let result;
+        try {
+            result = parser.parse(markdown);
+        } catch(err) {
+            _throwParseException(markdown,err.message,markdownFileName);
+        }
         if (result.status) {
             return serializer.toJSON(serializer.fromJSON(result.value));
         } else {
-            _throwParseError(markdown,result,markdownFileName);
+            _throwParseException(markdown,result,markdownFileName);
         }
     }
 

--- a/packages/markdown-template/lib/TypeVisitor.js
+++ b/packages/markdown-template/lib/TypeVisitor.js
@@ -61,7 +61,7 @@ class TypeVisitor {
         case 'VariableDefinition':
         case 'FormattedVariableDefinition': {
             if (!currentModel) {
-                _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
             }
             if (thing.name === 'this') {
                 const property = currentModel;
@@ -87,7 +87,7 @@ class TypeVisitor {
                 }
             } else {
                 if (!currentModel.getProperty) {
-                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
                 }
                 const property = currentModel.getProperty(thing.name);
                 if (property) {
@@ -110,7 +110,7 @@ class TypeVisitor {
                         thing.elementType = elementType;
                     }
                 } else {
-                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
                 }
             }
         }
@@ -118,12 +118,12 @@ class TypeVisitor {
         case 'ClauseDefinition': {
             if (parameters.kind === 'contract') {
                 if (!currentModel) {
-                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
                 }
                 const property = currentModel.getOwnProperty(thing.name);
                 let nextModel;
                 if (!property) {
-                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
                 }
                 if (property.isPrimitive()) {
                     nextModel = property;
@@ -139,7 +139,7 @@ class TypeVisitor {
                 });
             } else {
                 if (!currentModel) {
-                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                    _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
                 }
                 thing.elementType = currentModel.getFullyQualifiedName();
                 TypeVisitor.visitChildren(this, thing, parameters);
@@ -150,7 +150,7 @@ class TypeVisitor {
             const property = currentModel.getOwnProperty(thing.name);
             let nextModel;
             if (!property) {
-                _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
             }
             if (property.isPrimitive()) {
                 nextModel = property;
@@ -170,10 +170,10 @@ class TypeVisitor {
             const property = currentModel.getOwnProperty(thing.name);
             let nextModel;
             if (!property) {
-                _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
             }
             if (!property.isArray()) {
-                _throwTemplateExceptionForElement('List template not on an array property: ' + thing.name);
+                _throwTemplateExceptionForElement('List template not on an array property: ' + thing.name, thing);
             }
             if (property.isPrimitive()) {
                 nextModel = property;
@@ -193,10 +193,10 @@ class TypeVisitor {
             const property = currentModel.getOwnProperty(thing.name);
             let nextModel;
             if (!property) {
-                _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
             }
             if (!property.isArray()) {
-                _throwTemplateExceptionForElement('Join template not on an array property: ' + thing.name);
+                _throwTemplateExceptionForElement('Join template not on an array property: ' + thing.name, thing);
             }
             if (property.isPrimitive()) {
                 nextModel = property;
@@ -216,10 +216,10 @@ class TypeVisitor {
             const property = currentModel.getOwnProperty(thing.name);
             let nextModel;
             if (!property) {
-                _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
             }
             if (property.getType() !== 'Boolean') {
-                _throwTemplateExceptionForElement('Conditional template not on a boolean property: ' + thing.name);
+                _throwTemplateExceptionForElement('Conditional template not on a boolean property: ' + thing.name, thing);
             }
             nextModel = property;
             TypeVisitor.visitChildren(this, thing, {
@@ -240,10 +240,10 @@ class TypeVisitor {
             const property = currentModel.getOwnProperty(thing.name);
             let nextModel;
             if (!property) {
-                _throwTemplateExceptionForElement('Unknown property: ' + thing.name);
+                _throwTemplateExceptionForElement('Unknown property: ' + thing.name, thing);
             }
             if (!property.isOptional()) {
-                _throwTemplateExceptionForElement('Optional template not on an optional property: ' + thing.name);
+                _throwTemplateExceptionForElement('Optional template not on an optional property: ' + thing.name, thing);
             }
             if (property.isPrimitive()) {
                 thing.elementType = property.getFullyQualifiedTypeName();

--- a/packages/markdown-template/test/TemplateMarkTransformer.js
+++ b/packages/markdown-template/test/TemplateMarkTransformer.js
@@ -133,7 +133,7 @@ const parseFailures = [
     {name:'err6',desc:'wrong text',kind:'contract','error':'Parse error at line 1 column 45\n'},
     {name:'err7',desc:'wrong text',kind:'contract','error':'Parse error at line 7 column 23\nThere is a penalty of .10% for non compliance.\n                      ^^^^^^^^^^^^^^^^^^\nExpected: An Integer literal'},
     {name:'err8',desc:'',kind:'contract','error':'Parse error at line 4 column 73\nThis is a contract between "Steve" and "Betty" for the amount of 3131.0 ZZZ.'},
-    {name:'errFormula',desc:'inconsistent variables',kind:'contract','error':'Parse error at line 8 column 11\nAnd this: {%something something%}} is a computed value.\n          ^^^^^^^^^^^'},
+    {name:'errFormula',desc:'wrong formula',kind:'contract','error':'Parse error at line 8 column 11\nAnd this: {%something something%}} is a computed value.\n          ^^^^^^^^^^^'},
     {name:'errDateTime',desc:'',kind:'clause','error':'Parse error at line 1 column 73\nThis is a contract between "Steve" and "Betty" for the amount of 3131.0 GRR, even in the presence of force majeure.'},
     {name:'errLarge',desc:'',kind:'contract','error':'Parse error at line 804 column 40\nThis is a contract between "Steve" and Betty" for the amount of 3131.0 EUR.'},
     {name:'errRepeat',desc:'inconsistent variables',kind:'clause','error':'Inconsistent values for variable seller: Steve and Betty'},


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Traps low-level error for inconsistent variable in parser to return them as `ParseException`
- Also passes ast node to template exception (unused for the time being, but consistent with the API)
