### PR TITLE
fix(markdown-pdf): crash with empty headings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "markdown-transform",
-	"version": "0.12.3",
+	"version": "0.12.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/markdown-pdf/src/ToPdfMakeVisitor.js
+++ b/packages/markdown-pdf/src/ToPdfMakeVisitor.js
@@ -222,9 +222,10 @@ class ToPdfMakeVisitor {
             break;
         case 'Heading': {
             const child = this.processChildNodes(thing,parameters);
+            const text = child && child[0] && child[0].text ? child[0].text : '';
             result.style = ToPdfMakeVisitor.getHeadingType(thing);
-            result.text = `\n${child[0].text}\n`;
-            result.tocItem = true;
+            result.text = `\n${text}\n`;
+            result.tocItem = text.length > 0 ? true : false;
         }
             break;
         case 'ThematicBreak': {

--- a/packages/markdown-pdf/test/data/contract2.md
+++ b/packages/markdown-pdf/test/data/contract2.md
@@ -1,0 +1,43 @@
+Cicero 0.21 Migration
+====
+
+Demo Day Aug 19th!
+----
+
+## 
+
+{{#clause f30a9f03-8d0f-481a-81bb-4a64f46ab297 src="ap://acceptance-of-delivery@0.14.0#5d2fd778622e85e0f9224be383df3db2d4dfdc878d70b94a0a6231d53b3bf5ee"}}
+Acceptance of Delivery.
+----
+
+"Barilla" will be deemed to have completed its delivery obligations
+if in "Acme"'s opinion, the "Pasta" satisfies the
+Acceptance Criteria, and "Acme" notifies "Barilla" in writing
+that it is accepting the "Pasta".
+
+Inspection and Notice.
+----
+
+"Acme" will have 10 Business Days to inspect and
+evaluate the "Pasta" on the delivery date before notifying
+"Barilla" that it is either accepting or rejecting the
+"Pasta".
+
+Acceptance Criteria.
+----
+
+The "Acceptance Criteria" are the specifications the "Pasta"
+must meet for the "Barilla" to comply with its requirements and
+obligations under this agreement, detailed in "Attachment X", attached
+to this agreement.
+{{/clause}}
+
+{{#clause 1e3ba696-a406-4eb4-ac65-b969a7f950ae src="deyway://test-fixed-interests@0.1.0#4a2690f74dea49b151a410a2d0ea23bbd7c3860c8e9daf240747ec45f46383de"}}
+Fixed rate loan
+----
+
+This is a *fixed interest* loan to the amount of £100,000.00
+at the yearly interest rate of 2.5%
+with a loan term of 15,
+and monthly payments of {{%"£667.00"%}}
+{{/clause}}


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

### Changes
- Protect the PDF transform from CiceroMark document that contain headings without text
