### PR TITLE
fix(pdf) Fixes pdf generation for optionals/conditionals

### DIFF
--- a/packages/markdown-pdf/src/ToPdfMakeVisitor.js
+++ b/packages/markdown-pdf/src/ToPdfMakeVisitor.js
@@ -205,8 +205,10 @@ class ToPdfMakeVisitor {
             result.text = fixedText;
         }
             break;
+        case 'Optional':
         case 'Conditional': {
-            result.text = thing.nodes[0].text;
+            const child = this.processChildNodes(thing,parameters);
+            result.text = child;
         }
             break;
         case 'HtmlInline':


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #294 #295 
Fixes pdf generation for optionals and conditionals.

### Changes
- Adds support for optional template blocks `{{#optional}}`
- Fixes support for optional and conditional template blocks when they contain arbitrary markdown

### Tests
- First clause with conditional containing markdown, then two clauses with optionals: 
[tests.pdf](https://github.com/accordproject/markdown-transform/files/5111748/tests.pdf)
