### PR TITLE
fix(cicero) Bug in unquote for conditional/optional

### DIFF
--- a/packages/markdown-cicero/lib/UnquoteVariables.js
+++ b/packages/markdown-cicero/lib/UnquoteVariables.js
@@ -26,8 +26,6 @@ function mapObject(obj, stack) {
     switch (obj.$class) {
     // Strip quotes
     case 'org.accordproject.ciceromark.Formula':
-    case 'org.accordproject.ciceromark.Conditional':
-    case 'org.accordproject.ciceromark.Optional':
     case 'org.accordproject.ciceromark.Variable':
     case 'org.accordproject.ciceromark.FormattedVariable':
         stack.append({


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #290 
Fixes error when using the `unquoted` transform on CiceroMark with conditionals or optionals.

### Changes
- Does not treat conditional / optional nodes as if they are variables in the unquote variables transform
