### PR TITLE
fix(dingus) Should parse with HTML option on

### DIFF
--- a/packages/dingus/lib/index.js
+++ b/packages/dingus/lib/index.js
@@ -91,6 +91,7 @@ var mdHtml, mdSrc, permalink, scrollMap;
 var defaults = {
   templateMark : true,
   ciceroMark : false,
+  html : true,
 
   // options below are for demo only
   _highlight: true,


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #301 
Enables parsing for HTML blocks&inlines in the dingus with the `templatemark` and `ciceromark` option.
