### PR TITLE
fix(pdfmake) Use stack property instead of text for nested blocks

### DIFF
--- a/packages/markdown-pdf/src/ToPdfMakeVisitor.js
+++ b/packages/markdown-pdf/src/ToPdfMakeVisitor.js
@@ -172,7 +172,7 @@ class ToPdfMakeVisitor {
         case 'BlockQuote':
         case 'Item':
         case 'Clause': {
-            result.text = this.processChildNodes(thing,parameters);
+            result.stack = this.processChildNodes(thing,parameters);
         }
             break;
         case 'Link':
@@ -208,7 +208,7 @@ class ToPdfMakeVisitor {
         case 'Optional':
         case 'Conditional': {
             const child = this.processChildNodes(thing,parameters);
-            result.text = child;
+            result.stack = child;
         }
             break;
         case 'HtmlInline':


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Issue #299 #298
Fixes various issues with pdf generation.

### Changes
- Switch from `text` to `stack` in pdfmake JSON for complex blocks
- Fixes various issues with lists, blockquotes and clauses text in the generated pdf

### Flags
- I have low confidence -- not sure if it breaks other things, my first time looking at pdfmake.

### Samples

For:
```
This is the introduction.
> 
> This is a quote.
> 
> This is more text.
>
This is the conclusion.

This is a list
- Foo

  Bar
```

Before: 
[test0.pdf](https://github.com/accordproject/markdown-transform/files/5143202/test0.pdf)

After:
[test.pdf](https://github.com/accordproject/markdown-transform/files/5143203/test.pdf)


For: [contract-5f4513931f0dca001b5aff0c-2020-08-25T13_37_44.813Z.md.zip](https://github.com/accordproject/markdown-transform/files/5124043/contract-5f4513931f0dca001b5aff0c-2020-08-25T13_37_44.813Z.md.zip)

Before:
[danscontract0.pdf](https://github.com/accordproject/markdown-transform/files/5143212/danscontract0.pdf)

After:
[danscontract.pdf](https://github.com/accordproject/markdown-transform/files/5143213/danscontract.pdf)

Also fixes weird margins in clause text:

<img width="968" alt="Screenshot 2020-08-28 at 12 42 10 PM" src="https://user-images.githubusercontent.com/670099/91592077-f61a3680-e92b-11ea-99f3-3f6ab7003e8d.png">

### Also

This fixes images inside lists, reported in #298 tested here with a "hello world" image

```
**SIGNATURES**
-  **Jack Walnut**
   -  OTP Sent To: jackwalnut@gmail.com
   -  OTP Sent At: 17-Dec-2020 15:10:35
   -  OTP Verified At: 17-Dec-2020 15:11:23
   -  Signing Completed At: 17-Dec-2020 15:00:00
   -  ![Hello World](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEYAAAAUCAAAAAAVAxSkAAABrUlEQVQ4y+3TPUvDQBgH8OdDOGa+oUMgk2MpdHIIgpSUiqC0OKirgxYX8QVFRQRpBRF8KShqLbgIYkUEteCgFVuqUEVxEIkvJFhae3m8S2KbSkcFBw9yHP88+eXucgH8kQZ/jSm4VDaIy9RKCpKac9NKgU4uEJNwhHhK3qvPBVO8rxRWmFXPF+NSM1KVMbwriAMwhDgVcrxeMZm85GR0PhvGJAAmyozJsbsxgNEir4iEjIK0SYqGd8sOR3rJAGN2BCEkOxhxMhpd8Mk0CXtZacxi1hr20mI/rzgnxayoidevcGuHXTC/q6QuYSMt1jC+gBIiMg12v2vb5NlklChiWnhmFZpwvxDGzuUzV8kOg+N8UUvNBp64vy9q3UN7gDXhwWLY2nMC3zRDibfsY7wjEkY79CdMZhrxSqqzxf4ZRPXwzWJirMicDa5KwiPeARygHXKNMQHEy3rMopDR20XNZGbJzUtrwDC/KshlLDWyqdmhxZzCsdYmf2fWZPoxCEDyfIvdtNQH0PRkH6Q51g8rFO3Qzxh2LbItcDCOpmuOsV7ntNaERe3v/lP/zO8yn4N+yNPrekmPAAAAAElFTkSuQmCC)
-  **Betty Beetroot**
   -  OTP Sent To: bettybeetroot@gmail.com
   -  OTP Sent At: 17-Dec-2020 15:10:35
   -  OTP Verified At: 17-Dec-2020 15:11:23
   -  Signing Completed At: 17-Dec-2020 15:00:00
   -  ![Hello World](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEYAAAAUCAAAAAAVAxSkAAABrUlEQVQ4y+3TPUvDQBgH8OdDOGa+oUMgk2MpdHIIgpSUiqC0OKirgxYX8QVFRQRpBRF8KShqLbgIYkUEteCgFVuqUEVxEIkvJFhae3m8S2KbSkcFBw9yHP88+eXucgH8kQZ/jSm4VDaIy9RKCpKac9NKgU4uEJNwhHhK3qvPBVO8rxRWmFXPF+NSM1KVMbwriAMwhDgVcrxeMZm85GR0PhvGJAAmyozJsbsxgNEir4iEjIK0SYqGd8sOR3rJAGN2BCEkOxhxMhpd8Mk0CXtZacxi1hr20mI/rzgnxayoidevcGuHXTC/q6QuYSMt1jC+gBIiMg12v2vb5NlklChiWnhmFZpwvxDGzuUzV8kOg+N8UUvNBp64vy9q3UN7gDXhwWLY2nMC3zRDibfsY7wjEkY79CdMZhrxSqqzxf4ZRPXwzWJirMicDa5KwiPeARygHXKNMQHEy3rMopDR20XNZGbJzUtrwDC/KshlLDWyqdmhxZzCsdYmf2fWZPoxCEDyfIvdtNQH0PRkH6Q51g8rFO3Qzxh2LbItcDCOpmuOsV7ntNaERe3v/lP/zO8yn4N+yNPrekmPAAAAAElFTkSuQmCC)
```

[sig.pdf](https://github.com/accordproject/markdown-transform/files/5143256/sig.pdf)
