### PR TITLE
Added support for HTTP URL images in PDF Transform

### DIFF
--- a/packages/markdown-pdf/src/PdfTransformer.js
+++ b/packages/markdown-pdf/src/PdfTransformer.js
@@ -175,16 +175,20 @@ class PdfTransformer {
 
         const printer = new PdfPrinter(fonts);
 
-        const placeholderImage = "iVBORw0KGgoAAAANSUhEUgAAAFAAAAA8CAIAAAB+RarbAAADfUlEQVRo3u2b127DMAxF+///1uy9JzKRvWcvYEBQNGxJkXfvQ5Fh1zoiRZEC8/NOmX5SCjwejzOZzG9CBTQAfgAnmJYwfwD/pkAewJiS6XQa37W6XC7z+bw38Gq1yuVy5G2j0bjdbvFCvVwuGLaqhfH6er3WajXyCeZps9nEAvX1ek0mk2w2SwZfLBa9gZ07Edbo6RkMBvgwyrSHw6FcLtNLcjQaPZ9PJWBH+/2+UCiQryqVyvl8jiDq4/GAPWjzVKvV0+kkRHMDhu73e7vdJt/CWxaLRaRo1+s1bRWMcDab0RfoATsCJL0wMAWYiNBREWtarRZtWLzFh8xlJsAQnBkuTS7DpMLhQ6SFGWkbYDwwtfBKQ2AnkjFLBYEt+EiGxYklSg+j3+9jGcuuNwd2hC2K3tCxgfFe5JMQchF46SwYYRnB2f2ub4EhpCL0zo5EBemKyo1YF5iv+XwO18BfvMYnwFC5d7vdlkolOjhhy1XxLwvAjpB40pONuXexDBI9xg9pdTodsosIxSQFmG6kU4rjtAYMHY9HMuuYclmiR+cDLkKMlWGQ+ITVhLnTGqRNYMd6iBkYECk4GR9mMnh3IRMUbnj453hEt9s12A4tA7tHdRc3lqler9uN/MEBI13heWCoZrMJiw2HQ7wQMgudJQbAsBXvsUxw2u12dDVKtrr4AWPr4k0nTM4Q7XkvsOjVAQHDdAwG1rMsJeanxn2XiiIwNg+GAWmp7GL+CBFpRsyAsSGtPyWrpYXOb7HwDi5oKQoZIn9+GL81rL7UeX9GJhPLbUnlsIKuaYl57ZZfUQFm6gEiWR0fY2Csz16vJ0zC/DgPDh8YhaSwbEDt5cfjQgZGRsHTor7171QwZGAcvimWhAkBRk2rkmAnB5gpCXEY4vcTQwZmjgSwehMOjFPVLSWfInOkc+l/4GQB5zipZM7OqSWKCsVTe3+BsYtis5Gd1MoeT6QCTGoMHIPrLnvLwHTviOws/ntgOhvV7baxBsz3jvhnYci428YCsLB3RPEUyhj4bdpt8y2wrHdE18EMgN9G3TbmwO69I0FKq9vGENizdyRgqXfbaAMr9o6EIpVuGz1g9d6RsOTZbaMKrNs7EqLcu228gc16R0KXrNvGA9i4dyQKEnbbqPZL6/aOREdMt40SsEHvSKREd9toWDjJPwFI3Y88UvcznvQodcB/LBIdvQmJEjwAAAAASUVORK5CYII=";
+        const placeholderImage = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAA8CAIAAAB+RarbAAADfUlEQVRo3u2b127DMAxF+///1uy9JzKRvWcvYEBQNGxJkXfvQ5Fh1zoiRZEC8/NOmX5SCjwejzOZzG9CBTQAfgAnmJYwfwD/pkAewJiS6XQa37W6XC7z+bw38Gq1yuVy5G2j0bjdbvFCvVwuGLaqhfH6er3WajXyCeZps9nEAvX1ek0mk2w2SwZfLBa9gZ07Edbo6RkMBvgwyrSHw6FcLtNLcjQaPZ9PJWBH+/2+UCiQryqVyvl8jiDq4/GAPWjzVKvV0+kkRHMDhu73e7vdJt/CWxaLRaRo1+s1bRWMcDab0RfoATsCJL0wMAWYiNBREWtarRZtWLzFh8xlJsAQnBkuTS7DpMLhQ6SFGWkbYDwwtfBKQ2AnkjFLBYEt+EiGxYklSg+j3+9jGcuuNwd2hC2K3tCxgfFe5JMQchF46SwYYRnB2f2ub4EhpCL0zo5EBemKyo1YF5iv+XwO18BfvMYnwFC5d7vdlkolOjhhy1XxLwvAjpB40pONuXexDBI9xg9pdTodsosIxSQFmG6kU4rjtAYMHY9HMuuYclmiR+cDLkKMlWGQ+ITVhLnTGqRNYMd6iBkYECk4GR9mMnh3IRMUbnj453hEt9s12A4tA7tHdRc3lqler9uN/MEBI13heWCoZrMJiw2HQ7wQMgudJQbAsBXvsUxw2u12dDVKtrr4AWPr4k0nTM4Q7XkvsOjVAQHDdAwG1rMsJeanxn2XiiIwNg+GAWmp7GL+CBFpRsyAsSGtPyWrpYXOb7HwDi5oKQoZIn9+GL81rL7UeX9GJhPLbUnlsIKuaYl57ZZfUQFm6gEiWR0fY2Csz16vJ0zC/DgPDh8YhaSwbEDt5cfjQgZGRsHTor7171QwZGAcvimWhAkBRk2rkmAnB5gpCXEY4vcTQwZmjgSwehMOjFPVLSWfInOkc+l/4GQB5zipZM7OqSWKCsVTe3+BsYtis5Gd1MoeT6QCTGoMHIPrLnvLwHTviOws/ntgOhvV7baxBsz3jvhnYci428YCsLB3RPEUyhj4bdpt8y2wrHdE18EMgN9G3TbmwO69I0FKq9vGENizdyRgqXfbaAMr9o6EIpVuGz1g9d6RsOTZbaMKrNs7EqLcu228gc16R0KXrNvGA9i4dyQKEnbbqPZL6/aOREdMt40SsEHvSKREd9toWDjJPwFI3Y88UvcznvQodcB/LBIdvQmJEjwAAAAASUVORK5CYII=";
 
         // Asynchronously retrieve image as Base64 encoded data from URL.
         const getRemoteImageData = async (url) => {
             try {
-                const buffer = await axios.get(url, { responseType: 'arraybuffer' });
-                return Buffer.from(buffer.data);
+                if (options.offline) {
+                    return placeholderImage;
+                } else {
+                    const buffer = await axios.get(url, { responseType: 'arraybuffer' });
+                    return Buffer.from(buffer.data);
+                }
             } catch (err) {
                 // Failed to retrieve image buffer data from URL - use placeholder instead.
-                return ("data:image/png;base64," + placeholderImage);
+                return placeholderImage;
             }
         };
 

--- a/packages/markdown-pdf/src/PdfTransformer.js
+++ b/packages/markdown-pdf/src/PdfTransformer.js
@@ -22,6 +22,7 @@ let pdfjsLib = require('pdfjs-dist/es5/build/pdf.js');
 const CiceroMarkTransformer = require('@accordproject/markdown-cicero').CiceroMarkTransformer;
 const PdfPrinter = require('pdfmake');
 const ToPdfMakeVisitor = require('./ToPdfMakeVisitor');
+const axios = require('axios');
 const fonts = {
     Courier: {
         normal: 'Courier',
@@ -174,6 +175,40 @@ class PdfTransformer {
 
         const printer = new PdfPrinter(fonts);
 
+        const placeholderImage = "iVBORw0KGgoAAAANSUhEUgAAAFAAAAA8CAIAAAB+RarbAAADfUlEQVRo3u2b127DMAxF+///1uy9JzKRvWcvYEBQNGxJkXfvQ5Fh1zoiRZEC8/NOmX5SCjwejzOZzG9CBTQAfgAnmJYwfwD/pkAewJiS6XQa37W6XC7z+bw38Gq1yuVy5G2j0bjdbvFCvVwuGLaqhfH6er3WajXyCeZps9nEAvX1ek0mk2w2SwZfLBa9gZ07Edbo6RkMBvgwyrSHw6FcLtNLcjQaPZ9PJWBH+/2+UCiQryqVyvl8jiDq4/GAPWjzVKvV0+kkRHMDhu73e7vdJt/CWxaLRaRo1+s1bRWMcDab0RfoATsCJL0wMAWYiNBREWtarRZtWLzFh8xlJsAQnBkuTS7DpMLhQ6SFGWkbYDwwtfBKQ2AnkjFLBYEt+EiGxYklSg+j3+9jGcuuNwd2hC2K3tCxgfFe5JMQchF46SwYYRnB2f2ub4EhpCL0zo5EBemKyo1YF5iv+XwO18BfvMYnwFC5d7vdlkolOjhhy1XxLwvAjpB40pONuXexDBI9xg9pdTodsosIxSQFmG6kU4rjtAYMHY9HMuuYclmiR+cDLkKMlWGQ+ITVhLnTGqRNYMd6iBkYECk4GR9mMnh3IRMUbnj453hEt9s12A4tA7tHdRc3lqler9uN/MEBI13heWCoZrMJiw2HQ7wQMgudJQbAsBXvsUxw2u12dDVKtrr4AWPr4k0nTM4Q7XkvsOjVAQHDdAwG1rMsJeanxn2XiiIwNg+GAWmp7GL+CBFpRsyAsSGtPyWrpYXOb7HwDi5oKQoZIn9+GL81rL7UeX9GJhPLbUnlsIKuaYl57ZZfUQFm6gEiWR0fY2Csz16vJ0zC/DgPDh8YhaSwbEDt5cfjQgZGRsHTor7171QwZGAcvimWhAkBRk2rkmAnB5gpCXEY4vcTQwZmjgSwehMOjFPVLSWfInOkc+l/4GQB5zipZM7OqSWKCsVTe3+BsYtis5Gd1MoeT6QCTGoMHIPrLnvLwHTviOws/ntgOhvV7baxBsz3jvhnYci428YCsLB3RPEUyhj4bdpt8y2wrHdE18EMgN9G3TbmwO69I0FKq9vGENizdyRgqXfbaAMr9o6EIpVuGz1g9d6RsOTZbaMKrNs7EqLcu228gc16R0KXrNvGA9i4dyQKEnbbqPZL6/aOREdMt40SsEHvSKREd9toWDjJPwFI3Y88UvcznvQodcB/LBIdvQmJEjwAAAAASUVORK5CYII=";
+
+        // Asynchronously retrieve image as Base64 encoded data from URL.
+        const getRemoteImageData = async (url) => {
+            try {
+                const buffer = await axios.get(url, { responseType: 'arraybuffer' });
+                return Buffer.from(buffer.data);
+            } catch (err) {
+                // Failed to retrieve image buffer data from URL - use placeholder instead.
+                return ("data:image/png;base64," + placeholderImage);
+            }
+        };
+
+        // Walk a JSON object and find any image key starting with 'http' and 
+        // substitute the URL with the image buffer data. 
+        const findReplaceImageUrls = async (object) => {
+            await Promise.all(
+                Object.keys(object).map(async (key) => {
+                    if (Array.isArray(object[key])) {
+                        object[key] = await Promise.all(
+                            object[key].map(async (obj) => await findReplaceImageUrls(obj))
+                        );
+                    } else if (typeof object[key] === 'object') {
+                        object[key] = await findReplaceImageUrls(object[key]);
+                    } else {
+                        if (key === 'image' && typeof object[key] === 'string' && object[key].startsWith('http')) {
+                            object[key] = await getRemoteImageData(object[key]);
+                        }
+                    }
+                })
+            );
+            return object;
+        };
+
         if(!input.getType) {
             input = this.ciceroMarkTransformer.getSerializer().fromJSON(input);
         }
@@ -187,6 +222,7 @@ class PdfTransformer {
 
         const dd = parameters.result;
         // console.log(JSON.stringify(dd, null, 2));
+        await findReplaceImageUrls(dd);
 
         dd.defaultStyle = {
             fontSize: 12,

--- a/packages/markdown-pdf/src/PdfTransformer.js
+++ b/packages/markdown-pdf/src/PdfTransformer.js
@@ -177,7 +177,7 @@ class PdfTransformer {
 
         const placeholderImage = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAA8CAIAAAB+RarbAAADfUlEQVRo3u2b127DMAxF+///1uy9JzKRvWcvYEBQNGxJkXfvQ5Fh1zoiRZEC8/NOmX5SCjwejzOZzG9CBTQAfgAnmJYwfwD/pkAewJiS6XQa37W6XC7z+bw38Gq1yuVy5G2j0bjdbvFCvVwuGLaqhfH6er3WajXyCeZps9nEAvX1ek0mk2w2SwZfLBa9gZ07Edbo6RkMBvgwyrSHw6FcLtNLcjQaPZ9PJWBH+/2+UCiQryqVyvl8jiDq4/GAPWjzVKvV0+kkRHMDhu73e7vdJt/CWxaLRaRo1+s1bRWMcDab0RfoATsCJL0wMAWYiNBREWtarRZtWLzFh8xlJsAQnBkuTS7DpMLhQ6SFGWkbYDwwtfBKQ2AnkjFLBYEt+EiGxYklSg+j3+9jGcuuNwd2hC2K3tCxgfFe5JMQchF46SwYYRnB2f2ub4EhpCL0zo5EBemKyo1YF5iv+XwO18BfvMYnwFC5d7vdlkolOjhhy1XxLwvAjpB40pONuXexDBI9xg9pdTodsosIxSQFmG6kU4rjtAYMHY9HMuuYclmiR+cDLkKMlWGQ+ITVhLnTGqRNYMd6iBkYECk4GR9mMnh3IRMUbnj453hEt9s12A4tA7tHdRc3lqler9uN/MEBI13heWCoZrMJiw2HQ7wQMgudJQbAsBXvsUxw2u12dDVKtrr4AWPr4k0nTM4Q7XkvsOjVAQHDdAwG1rMsJeanxn2XiiIwNg+GAWmp7GL+CBFpRsyAsSGtPyWrpYXOb7HwDi5oKQoZIn9+GL81rL7UeX9GJhPLbUnlsIKuaYl57ZZfUQFm6gEiWR0fY2Csz16vJ0zC/DgPDh8YhaSwbEDt5cfjQgZGRsHTor7171QwZGAcvimWhAkBRk2rkmAnB5gpCXEY4vcTQwZmjgSwehMOjFPVLSWfInOkc+l/4GQB5zipZM7OqSWKCsVTe3+BsYtis5Gd1MoeT6QCTGoMHIPrLnvLwHTviOws/ntgOhvV7baxBsz3jvhnYci428YCsLB3RPEUyhj4bdpt8y2wrHdE18EMgN9G3TbmwO69I0FKq9vGENizdyRgqXfbaAMr9o6EIpVuGz1g9d6RsOTZbaMKrNs7EqLcu228gc16R0KXrNvGA9i4dyQKEnbbqPZL6/aOREdMt40SsEHvSKREd9toWDjJPwFI3Y88UvcznvQodcB/LBIdvQmJEjwAAAAASUVORK5CYII=";
 
-        // Asynchronously retrieve image as Base64 encoded data from URL.
+        // Asynchronously retrieve image as buffer data from URL.
         const getRemoteImageData = async (url) => {
             try {
                 if (options.offline) {

--- a/packages/markdown-pdf/test/data/contract.md
+++ b/packages/markdown-pdf/test/data/contract.md
@@ -80,13 +80,23 @@ obligations under this agreement, detailed in "Attachment X", attached
 to this agreement.
 {{/clause}}
 
-## Image (Heading Two)
+## Image URL (Heading Two)
+
+This is an image link using a http url.
+
+![Accord](https://avatars0.githubusercontent.com/u/29445438?s=200&v=4)
+
+This is an image link using an unreachable http url - to test "offline" mode.
+
+![Unreachable Image](http://some.unreachable.destination)
+
+### Image Data URI (Heading Three)
 
 This is an image link using a data uri.
 
 ![accord project](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQQAAAEEBAMAAAA8Jlc5AAAAIVBMVEVHcEw+Vok+Vok+Vok+Vok+Vok+Vok+Vok+Vok+Vok+Vokt3bPwAAAACnRSTlMAHG2/T4juo9gzwLCb9wAAB4NJREFUeNrtnT1zrDYUhs03bOWkuHeGypM0GSpn0lHtpKRyWqq9LZVrKs+ko3JN5e+1/SvTmF1gkd6DdCQ2d1C79iIkPZLOowN7cbGWtaxlLWtZy1rWwlk+ieXDXBVyYhVezVWhIFbh3VwVUmpP3Burgketwo2xKrjUKtwZq4JDrcLj8kg8matCRqzC8xkgcbk8ElfLI3H9UyPRLI9EeT5IfPwiKJVxJOKvK7yI/qA2jkTwdYU9Ws9vjVUh+brCm+gPQntIbAWfR6in+JAQNbSPekq/tF+X2In+oEPCXBVCKhJb40i8LoeET0ViZ64nKrBJtoBEDTbJFpAo0CYZ9RQfEh9oi2sOieh8kHhH6/mCSHjmI3yEhGsvwr8DW1yDSHyjImE+wn9CUd/N8khYiPAvl0MiB5tkC0hkIG507EmvR7TF/amRcFHc2C6PRGxPel2BLe7TckgkZ4SE+Qj/CUV9C0b4rXHplZwBEijCD+xJr1vQTAalV9fXD2iLu6D0Ks9HeplHYknpVf1/pJdBJAqi9LIQ4VuSXs5vp+UPux44kjh/S9IrVDkZ5kWiVTkZ5pVe0oOYnRXp1SglS3AikaglS2SMSARqyRIbRiRitWQJjxGJVi1ZgjPCL9WSJTilV6OYP8QnvRLV/CG+CD9QzR/i88CxarIEn/Q6AvHvX4PSWJNepSgxg+qB3xmBuJ65SeZCwhEmZkS2pJcrTMyAm2QuDxyLEzMqYoSvi0Qqxq+2JL0yca5SYckD5+JcpY0d6eVIcpUiO9LLleQq+VQPrBfhe5JcpUMLIZoe2YA46VQ7HjiTpe9lVqRXLkvfS5H04kDCkabveTaklytN33NteGBPmr7n2JBeqXyTlhOllw4ShTyjNSNKrz0DEI0cCSS9NJA4APH7dKfG5qVX15Cfv053qoXkx244PTvTSJA98INyFTaHm8+nO9V88mNxGALZNBKlcelVH/bA6TQS1ORH9Qj/OB14ciSMSS//OCm6ciSMZXpFxy0wQMJYhB/27lGAhOnkx6I3AARIUDO99tpAXIiQMJ3pVfVusUPieeg5crPSy+/bTXcR6RX1h7uziPQKB3eY63ngDy0gPiYiCkseuB6M9lTtCSG9CL8a3KCn+ISQDhLJsJtdxSeEdJAIhk3oKD4hpCO9wtFAytU8sI70akf/m6k9NKeDRDmaVBSR0Mn0akbjSBUJ9Qj/AMR2OsomI6Ee4QfjZVYVCfXkx/hks/H3IH2gi/H25jK9WrDl6tbRPxES6tKrBKtsF2ld5cakVwO+uVtHLzNTSJwAIVhH3w/zBbv0CtC+s+omPc+U9IrBF/uH6dtFHlhVelGBuDvOF1tmJDIARHicvtHAVc30Qt/bHvczGTHCn/l4I2zd8jhaUZ8pPvHrIiCa42hFI1cxwkekJb07h/yqSS803wS9/oezmFqEn4GKx/22pSIxL8JHa0/av/GSiMSbEhBXoJUupza6LNILTrp5f7aJTUgvD0xozmDOhUioZHqlYFp3BytPYiL5EW1DvOH62xjwwDlY4tPhaC35pRcEohi2PERi/hO/LtqY18MgLeaXXgiI465t0gNwSC8EhD9q+IRfehUAiGg8/Cp26YWACMdXpCJBj/CpQGzH2zg26eUjIMox5iG39IqIQOynXTGH9NqAe0pOpnzYbnORQEAEp1uqill61aDV4tPlv2b2wOiW2tPPC2qEf88KRP/zkFd6weGdnwIT8XrgEAwdZ+KOfV7phfrVnfq8YpVeCAhvavTXRA/8PAuIG9CtN3Oabpb08tHin019HnJKLyoQ7/PWlTnSCwFxMfk5fIHRHCQKsKL4059zSi+0A4qmt6I1owdGQITT16I+3khAAu6Gi+kW/8aX6QVjgnp63HlU6XWtD0Q1fSmfT3qh+DARNLjDJ72QOApEN1OzSS/kCmJRl7J5YAhEK5rrUy4koDcqRXh7XB4YCuVGNMm5VCR2RCBeZuzaRkjoSi8EhCte8HIm6YV8sidexCASNOkFrXoqvtWUR3pBIDJxh3s8HhgCkYsXMZdHeqVEIF5ltlJPeqEh5cu+JWeRXlQgdrL6a3lguOJuZFUkI3FPML9vaFBvZU2k5YHhUlPLquhyRPhwwa1kVWR5zR06G/TlVeR44hedDUbyKjK85g4CEcqvwfCaO3gU0spbOtb3wPAopJRXMdDP9IJANLTjSw3phc4GE9TQjbb0QkchAbqJUld6wbPBGHVlqyu9oL9M0YDWfs0dBCJDWGu/5g4dhch2baPdryoSCAgHT/G6r7lDEtfFC53ua+4+iWNlh+PBBzXpBYHY4DhA8zV30OEWOBrSfM0dPNyp8QaY/HjjD2kFH0FYuqeIUzXphYDwKX5A77cduhv4R/BDJd8pLr1D4gf6uRMpEKhcU8wpLFtJL8FyJasC+VtudeovVenkttxJgEDlmXaWgMqLBAhUwLEK9Wv2GtUHKQjUxnzT6MQ72mGCAhLkoQzSUTSQINceZCBoINES/xPmYagjQf0tK5iNUit/kQ7PPEgkOrMaz6AKdOZ2HrRinRXOyASzlrWsZS1rWcta1nIo/wEcUfBmMVDvRAAAAABJRU5ErkJggg==)
 
-### Ordered List (Heading Three)
+#### Ordered List (Heading Four)
 
 This is is an ordered list:
 
@@ -94,7 +104,7 @@ This is is an ordered list:
 2. two
 3. three
 
-#### Unordered List (Heading Four)
+##### Unordered List (Heading Five)
 
 This is an unordered list:
 
@@ -102,7 +112,7 @@ This is an unordered list:
 - pears
 - peaches
 
-##### Bold Italic (Heading Five)
+###### Bold Italic (Heading Six)
 
 This is ***bold italic*** text. More text.
 


### PR DESCRIPTION
# Issue #260 
Added logic to PDF Transformer to retrieve remote images in TemplateMark as an image reference. 

For example:
`![Accord Logo](https://avatars0.githubusercontent.com/u/29445438?s=200&v=4)`

Logic added to PDF Transformer to walk the document definition and find all `image` objects, and replace the URL strings with image data.

### Changes

#### markdown-pdf/src/PDFTransformer.js
- findReplaceImageUrls
  - Walk a JSON object and find any image key starting with 'http' and substitute the URL with the image data.
  - findReplaceImageUrls is a recursive function.

- getRemoteImageData
  - Asynchronously retrieve image buffer data from URL.
  - if an error occurs, getRemoteImageData substitutes a base64 encoded placeholder image.


#### markdown-pdf/test/data/contract.md
- added `![Accord](https://avatars0.githubusercontent.com/u/29445438?s=200&v=4)` to test data.

### Offline Mode
- Added support for offline mode using offline option (e.g. `--offline`). 
- When in offline mode getRemoteImageData substitutes all HTTP URL images with a base64 encoded placeholder image.

