### PR TITLE
fix(markdown-slate): linked variables

### DIFF
--- a/packages/markdown-slate/lib/ToSlateVisitor.js
+++ b/packages/markdown-slate/lib/ToSlateVisitor.js
@@ -499,11 +499,24 @@ class ToSlateVisitor {
             if (thing.decorators) {
                 data.decorators = thing.decorators.map(x => parameters.serializer.toJSON(x));
             }
+
+            const calculatingChildren = this.processChildNodes(thing, parameters);
+            // This changes the variable names if they are inside a list so that they are not linked.
+            for(let i = 0; i < calculatingChildren.length; i++){
+                const listElements = calculatingChildren[i].children[0].children;
+                for(let j = 0; j < listElements.length; j++){
+                    if(listElements[j].type === 'variable'){
+                        const listVariables = `${listElements[j].data.name}${i}`;
+                        listElements[j].data.name = listVariables;
+                    }
+                }
+            }
+
             result = {
                 object: 'block',
                 data: data,
                 type: thing.type === 'ordered' ? 'ol_list' : 'ul_list',
-                children: this.processChildNodes(thing,parameters)
+                children: calculatingChildren
             };
         }
             break;


### PR DESCRIPTION
Signed-off-by: d-e-v-esh <59534570+d-e-v-esh@users.noreply.github.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Helps to resolve https://github.com/accordproject/web-components/issues/175

<!--- Provide an overall summary of the pull request -->

The list items of the `volumediscountolist` template have linked variables. This is because they all are dealing with the same kind of variables. Checking of those variables are inside of a list and if that is true then changing their names fixes this issue.


### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->


 - Each line in the list comes as an object and encased under the type `list_item`. 
 - They all have a key called `children` that contains an array with one element inside it.
 
![chrome_FhfxaXRWCx](https://user-images.githubusercontent.com/59534570/112170639-3b2fee00-8c19-11eb-85ca-3cfed7723719.png)

That element is another object with the type `paragraph` that contains the data for the actual data that is in the list item.

![ZiCAagdCY1](https://user-images.githubusercontent.com/59534570/112170786-58fd5300-8c19-11eb-9336-52b9834f3a58.png)

It contains another array called `children` with the data that is inside the line like this.

![chrome_kbQnAiimZi](https://user-images.githubusercontent.com/59534570/112170885-6d415000-8c19-11eb-816d-d3881a376d5a.png)

As you can see, it has 7 different objects as elements of the array. Each element is there to create a divide between the normal text and variables and all the variables have a type variable

Each variable contains an object called `data` where the name of the variable resides

![chrome_b8MvfbKAaf](https://user-images.githubusercontent.com/59534570/112170972-7e8a5c80-8c19-11eb-87dc-0b976a23eab0.png)

We have to change that name and it works. We basically check if a variable is inside a list item and if that is true then we add the index of the list next to the variable and it looks like this.

![chrome_auLJtPLeA9](https://user-images.githubusercontent.com/59534570/111881845-7becf480-89d8-11eb-93d2-4eb740c44aba.png)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`