### PR TITLE
fix(template) Properly extract number when parsing amounts

### DIFF
--- a/packages/markdown-template/lib/plugins/Double/parse.js
+++ b/packages/markdown-template/lib/plugins/Double/parse.js
@@ -45,7 +45,8 @@ function doubleParser(format) {
         // remove null or empty strings
         fields = fields.filter(x => x !== '' && x !== null);
         const parsers = fields.map(parserOfField);
-        return seqParser(parsers);
+        return seqParser(parsers)
+            .map((value) => value[0]);
     } else {
         return parseDoubleIEEE();
     }

--- a/packages/markdown-template/lib/plugins/Integer/parse.js
+++ b/packages/markdown-template/lib/plugins/Integer/parse.js
@@ -45,7 +45,8 @@ function integerParser(format) {
         // remove null or empty strings
         fields = fields.filter(x => x !== '' && x !== null);
         const parsers = fields.map(parserOfField);
-        return seqParser(parsers);
+        return seqParser(parsers)
+            .map((value) => value[0]);
     } else {
         return parseInteger();
     }

--- a/packages/markdown-template/lib/plugins/Long/parse.js
+++ b/packages/markdown-template/lib/plugins/Long/parse.js
@@ -45,7 +45,8 @@ function longParser(format) {
         // remove null or empty strings
         fields = fields.filter(x => x !== '' && x !== null);
         const parsers = fields.map(parserOfField);
-        return seqParser(parsers);
+        return seqParser(parsers)
+            .map((value) => value[0]);
     } else {
         return parseLong();
     }


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Closes #372

Fixes parser for amount, so they return a number rather than an array with a number in it.

### Changes
- Add a Parsimmon's `map` to extract the content of the amount.

