### PR TITLE
fix(CI) Should use npm install before publish to get external models

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           node-version: 14.x
     
       - name: Build
-        run: npx lerna bootstrap
+        run: npm ci
 
       - name: timestamp
         id: timestamp


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes

- GitHub workflow should use `npm ci` rather than `lerna bootstrap` or it won't get external models

### Context 

- Fix similar to the one in https://github.com/accordproject/ergo/pull/806
