### PR TITLE
feat: sets-up class for CiceroMark to OOXML transformer

### DIFF
--- a/packages/markdown-docx/src/CiceroMarkToOOXMLTransformer.js
+++ b/packages/markdown-docx/src/CiceroMarkToOOXMLTransformer.js
@@ -19,23 +19,18 @@
  */
 class CiceroMarkToOOXMLTransfomer {
 
-    /**
-     * Defines the different types of nodes for CiceroMark JSON
-     */
-    constructor() {
-        this.definedNodes = {
-            computedVariable: 'org.accordproject.ciceromark.ComputedVariable',
-            heading: 'org.accordproject.commonmark.Heading',
-            item: 'org.accordproject.commonmark.Item',
-            list: 'org.accordproject.commonmark.List',
-            listBlock: 'org.accordproject.ciceromark.ListBlock',
-            paragraph: 'org.accordproject.commonmark.Paragraph',
-            softbreak: 'org.accordproject.commonmark.Softbreak',
-            text: 'org.accordproject.commonmark.Text',
-            variable: 'org.accordproject.ciceromark.Variable',
-            emphasize: 'org.accordproject.commonmark.Emph',
-        };
-    }
+    definedNodes = {
+        computedVariable: 'org.accordproject.ciceromark.ComputedVariable',
+        heading: 'org.accordproject.commonmark.Heading',
+        item: 'org.accordproject.commonmark.Item',
+        list: 'org.accordproject.commonmark.List',
+        listBlock: 'org.accordproject.ciceromark.ListBlock',
+        paragraph: 'org.accordproject.commonmark.Paragraph',
+        softbreak: 'org.accordproject.commonmark.Softbreak',
+        text: 'org.accordproject.commonmark.Text',
+        variable: 'org.accordproject.ciceromark.Variable',
+        emphasize: 'org.accordproject.commonmark.Emph',
+    };
 
     /**
      * Transforms the given CiceroMark JSON to OOXML

--- a/packages/markdown-docx/src/CiceroMarkToOOXMLTransformer.js
+++ b/packages/markdown-docx/src/CiceroMarkToOOXMLTransformer.js
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * Transforms the ciceromark to OOXML
+ */
+class CiceroMarkToOOXMLTransfomer {
+
+    /**
+     * Defines the different types of nodes for CiceroMark JSON
+     */
+    constructor() {
+        this.definedNodes = {
+            computedVariable: 'org.accordproject.ciceromark.ComputedVariable',
+            heading: 'org.accordproject.commonmark.Heading',
+            item: 'org.accordproject.commonmark.Item',
+            list: 'org.accordproject.commonmark.List',
+            listBlock: 'org.accordproject.ciceromark.ListBlock',
+            paragraph: 'org.accordproject.commonmark.Paragraph',
+            softbreak: 'org.accordproject.commonmark.Softbreak',
+            text: 'org.accordproject.commonmark.Text',
+            variable: 'org.accordproject.ciceromark.Variable',
+            emphasize: 'org.accordproject.commonmark.Emph',
+        };
+    }
+
+    /**
+     * Transforms the given CiceroMark JSON to OOXML
+     *
+     * @param {Object} ciceromark CiceroMark JSON to be converted
+     * @param {Object} counter    Counter for different variables based on node name
+     * @param {string} ooxml      Initial OOXML string
+     * @returns {string} Converted OOXML string i.e. CicecoMark->OOXML
+     */
+    toOOXML(ciceromark, counter, ooxml) {
+        let globalOOXML = ooxml;
+        return globalOOXML;
+    }
+}
+
+module.exports = CiceroMarkToOOXMLTransfomer;


### PR DESCRIPTION
Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

Sets up the basic class definition for the CiceroMark to OOXML transformer

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Defines constructor
- <TWO> Defines the function for converting CiceroMark to OOXML

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [] Merging to `master` from `fork:branchname`