### PR TITLE
feat(markdown-docx): add API to return frequency of variables in CiceroMark (JSON) - #397

### DIFF
--- a/packages/markdown-docx/src/CiceroMarkToOOXML/index.js
+++ b/packages/markdown-docx/src/CiceroMarkToOOXML/index.js
@@ -39,6 +39,7 @@ class CiceroMarkToOOXMLTransfomer {
      */
     constructor() {
         this.globalOOXML = '';
+        this.counter = {};
     }
 
     /**
@@ -49,6 +50,15 @@ class CiceroMarkToOOXMLTransfomer {
      */
     getClass(node) {
         return node.$class;
+    }
+
+    /**
+     * Returns the counter holding variable counts for a CiceroMark.
+     *
+     * @returns {object} Counter for variables in CiceroMark
+     */
+    getCounter() {
+        return this.counter;
     }
 
     /**
@@ -138,6 +148,7 @@ class CiceroMarkToOOXMLTransfomer {
             this.getNodes(node, counter);
         });
         this.globalOOXML = wrapAroundDefaultDocxTags(this.globalOOXML);
+        this.counter = counter;
         return this.globalOOXML;
     }
 }


### PR DESCRIPTION
Return counter for variables in CiceroMark

Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide an overall summary of the pull request -->
Enhancement to the `CiceroMarkToOOXMLTransformer` by returning the counter for variables in CiceroMark of a template.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Use a class variable `counter` to store the counter.
- <TWO> A function `getCounter()` that returns the counter.

### Related Issues
- Pull Request #410
Raised as a part of the above PR.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`