### PR TITLE
refactor(markdown-docx): remove argument ooxml in `toOOXML` - #397

### DIFF
--- a/packages/markdown-docx/src/CiceroMarkToOOXML/index.js
+++ b/packages/markdown-docx/src/CiceroMarkToOOXML/index.js
@@ -137,11 +137,9 @@ class CiceroMarkToOOXMLTransfomer {
      * Transforms the given CiceroMark JSON to OOXML
      *
      * @param {Object} ciceromark CiceroMark JSON to be converted
-     * @param {string} ooxml      Initial OOXML string
      * @returns {string} Converted OOXML string i.e. CicecoMark->OOXML
      */
-    toOOXML(ciceromark, ooxml = '') {
-        this.globalOOXML = ooxml;
+    toOOXML(ciceromark) {
         ciceromark.nodes.forEach(node => {
             this.getNodes(node);
         });


### PR DESCRIPTION
Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide an overall summary of the pull request -->
Removes the `ooxml` argument in `toOOXML` function and update the docstrings accordingly.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Removes `ooxml` argument.
- <TWO> Docstring update.

### Related Issues
- Pull Request #411 <NUMBER>
Raised as a part of discussion in above PR.

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`