### PR TITLE
fix(pdf) Switch pdfjs import for latest distribution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14640,9 +14640,9 @@
 			}
 		},
 		"pdfjs-dist": {
-			"version": "2.7.570",
-			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.7.570.tgz",
-			"integrity": "sha512-/ZkA1FwkEOyDaq11JhMLazdwQAA0F9uwrP7h/1L9Akt9KWh1G5/tkzS+bPuUELq2s2GDFnaT+kooN/aSjT7DXQ=="
+			"version": "2.8.335",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.8.335.tgz",
+			"integrity": "sha512-2IKw7wP1RnzzWJcpkeZwF+cKROFiQext+/WburB6cgKwt9zc8rOyDH7a3FepdcciSGs8SDs/AuWe8qVx+iI6pw=="
 		},
 		"pdfkit": {
 			"version": "0.12.1",

--- a/packages/markdown-pdf/package.json
+++ b/packages/markdown-pdf/package.json
@@ -86,7 +86,7 @@
     "@accordproject/markdown-common": "0.14.0",
     "@accordproject/markdown-template": "0.14.0",
     "axios": "^0.21.1",
-    "pdfjs-dist": "^2.7.570",
+    "pdfjs-dist": "^2.8.335",
     "pdfmake": "^0.1.71",
     "type-of": "^2.0.1"
   },

--- a/packages/markdown-pdf/src/ToCiceroMark.js
+++ b/packages/markdown-pdf/src/ToCiceroMark.js
@@ -17,7 +17,7 @@
 // HACK few hacks to let PDF.js be loaded not as a module in global space.
 require('./domstubs.js').setStubs(global);
 
-let pdfjsLib = require('pdfjs-dist/es5/build/pdf.js');
+let pdfjsLib = require('pdfjs-dist/legacy/build/pdf.js');
 
 /**
  * Converts an pdf buffer to a CiceroMark DOM


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

# Closes #419 

### Changes

- Switch `pdfjs` import for latest distribution `es5` renamed to `legacy`

### Flags

- See also comment in https://stackoverflow.com/questions/64189359/reading-pdf-from-url-with-node-js-using-pdf-js

