### PR TITLE
refactor(markdown-docx): use DEFINE_NODES for nodeType and class

### DIFF
--- a/packages/markdown-docx/src/ToOOXMLVisitor/index.js
+++ b/packages/markdown-docx/src/ToOOXMLVisitor/index.js
@@ -27,7 +27,7 @@ const {
     CODE_PROPERTIES_RULE,
 } = require('./rules');
 const { wrapAroundDefaultDocxTags } = require('./helpers');
-const { DEFINED_NODES } = require('../constants');
+const { TRANSFORMED_NODES } = require('../constants');
 
 /**
  * Transforms the ciceromark to OOXML
@@ -66,12 +66,12 @@ class ToOOXMLVisitor {
             this.traverseNodes(node.nodes, properties);
         } else {
             for (let subNode of node) {
-                if (this.getClass(subNode) === DEFINED_NODES.text) {
+                if (this.getClass(subNode) === TRANSFORMED_NODES.text) {
                     let propertyTag = '';
                     for (let property of properties) {
-                        if (property === DEFINED_NODES.emphasize) {
+                        if (property === TRANSFORMED_NODES.emphasize) {
                             propertyTag += EMPHASIS_RULE();
-                        } else if (property === DEFINED_NODES.strong) {
+                        } else if (property === TRANSFORMED_NODES.strong) {
                             propertyTag += STRONG_RULE();
                         }
                     }
@@ -83,12 +83,12 @@ class ToOOXMLVisitor {
 
                     let tag = TEXT_WRAPPER_RULE(propertyTag, textValueTag);
                     this.tags = [...this.tags, tag];
-                } else if (this.getClass(subNode) === DEFINED_NODES.code) {
+                } else if (this.getClass(subNode) === TRANSFORMED_NODES.code) {
                     let propertyTag = CODE_PROPERTIES_RULE();
                     for (let property of properties) {
-                        if (property === DEFINED_NODES.emphasize) {
+                        if (property === TRANSFORMED_NODES.emphasize) {
                             propertyTag += EMPHASIS_RULE();
-                        } else if (property === DEFINED_NODES.strong) {
+                        } else if (property === TRANSFORMED_NODES.strong) {
                             propertyTag += STRONG_RULE();
                         }
                     }
@@ -98,7 +98,7 @@ class ToOOXMLVisitor {
 
                     let tag = TEXT_WRAPPER_RULE(propertyTag, textValueTag);
                     this.tags = [...this.tags, tag];
-                } else if (this.getClass(subNode) === DEFINED_NODES.variable) {
+                } else if (this.getClass(subNode) === TRANSFORMED_NODES.variable) {
                     const tag = subNode.name;
                     const type = subNode.elementType;
                     if (Object.prototype.hasOwnProperty.call(this.counter, tag)) {
@@ -119,11 +119,11 @@ class ToOOXMLVisitor {
                     const title = `${tag.toUpperCase()[0]}${tag.substring(1)}${this.counter[tag].count}`;
 
                     this.tags = [...this.tags, VARIABLE_RULE(title, tag, value, type)];
-                } else if (this.getClass(subNode) === DEFINED_NODES.softbreak) {
+                } else if (this.getClass(subNode) === TRANSFORMED_NODES.softbreak) {
                     this.tags = [...this.tags, SOFTBREAK_RULE()];
                 } else {
                     if (subNode.nodes) {
-                        if (this.getClass(subNode) === DEFINED_NODES.paragraph) {
+                        if (this.getClass(subNode) === TRANSFORMED_NODES.paragraph) {
                             this.traverseNodes(subNode.nodes, properties);
                             let ooxml = '';
                             for (let xmlTag of this.tags) {
@@ -134,7 +134,7 @@ class ToOOXMLVisitor {
                             this.globalOOXML += ooxml;
                             // Clear all the tags as all nodes of paragraph have been traversed.
                             this.tags = [];
-                        } else if (this.getClass(subNode) === DEFINED_NODES.heading) {
+                        } else if (this.getClass(subNode) === TRANSFORMED_NODES.heading) {
                             this.traverseNodes(subNode.nodes, properties);
                             let ooxml = '';
                             for (let xmlTag of this.tags) {

--- a/packages/markdown-docx/src/ToOOXMLVisitor/index.js
+++ b/packages/markdown-docx/src/ToOOXMLVisitor/index.js
@@ -27,21 +27,7 @@ const {
     CODE_PROPERTIES_RULE,
 } = require('./rules');
 const { wrapAroundDefaultDocxTags } = require('./helpers');
-
-const definedNodes = {
-    computedVariable: 'org.accordproject.ciceromark.ComputedVariable',
-    heading: 'org.accordproject.commonmark.Heading',
-    item: 'org.accordproject.commonmark.Item',
-    list: 'org.accordproject.commonmark.List',
-    listBlock: 'org.accordproject.ciceromark.ListBlock',
-    paragraph: 'org.accordproject.commonmark.Paragraph',
-    softbreak: 'org.accordproject.commonmark.Softbreak',
-    text: 'org.accordproject.commonmark.Text',
-    variable: 'org.accordproject.ciceromark.Variable',
-    emphasize: 'org.accordproject.commonmark.Emph',
-    strong: 'org.accordproject.commonmark.Strong',
-    code: 'org.accordproject.commonmark.Code'
-};
+const { DEFINED_NODES } = require('../constants');
 
 /**
  * Transforms the ciceromark to OOXML
@@ -80,12 +66,12 @@ class ToOOXMLVisitor {
             this.traverseNodes(node.nodes, properties);
         } else {
             for (let subNode of node) {
-                if (this.getClass(subNode) === definedNodes.text) {
+                if (this.getClass(subNode) === DEFINED_NODES.text) {
                     let propertyTag = '';
                     for (let property of properties) {
-                        if (property === definedNodes.emphasize) {
+                        if (property === DEFINED_NODES.emphasize) {
                             propertyTag += EMPHASIS_RULE();
-                        } else if (property === definedNodes.strong) {
+                        } else if (property === DEFINED_NODES.strong) {
                             propertyTag += STRONG_RULE();
                         }
                     }
@@ -97,12 +83,12 @@ class ToOOXMLVisitor {
 
                     let tag = TEXT_WRAPPER_RULE(propertyTag, textValueTag);
                     this.tags = [...this.tags, tag];
-                } else if (this.getClass(subNode) === definedNodes.code) {
+                } else if (this.getClass(subNode) === DEFINED_NODES.code) {
                     let propertyTag = CODE_PROPERTIES_RULE();
                     for (let property of properties) {
-                        if (property === definedNodes.emphasize) {
+                        if (property === DEFINED_NODES.emphasize) {
                             propertyTag += EMPHASIS_RULE();
-                        } else if (property === definedNodes.strong) {
+                        } else if (property === DEFINED_NODES.strong) {
                             propertyTag += STRONG_RULE();
                         }
                     }
@@ -112,7 +98,7 @@ class ToOOXMLVisitor {
 
                     let tag = TEXT_WRAPPER_RULE(propertyTag, textValueTag);
                     this.tags = [...this.tags, tag];
-                } else if (this.getClass(subNode) === definedNodes.variable) {
+                } else if (this.getClass(subNode) === DEFINED_NODES.variable) {
                     const tag = subNode.name;
                     const type = subNode.elementType;
                     if (Object.prototype.hasOwnProperty.call(this.counter, tag)) {
@@ -133,11 +119,11 @@ class ToOOXMLVisitor {
                     const title = `${tag.toUpperCase()[0]}${tag.substring(1)}${this.counter[tag].count}`;
 
                     this.tags = [...this.tags, VARIABLE_RULE(title, tag, value, type)];
-                } else if (this.getClass(subNode) === definedNodes.softbreak) {
+                } else if (this.getClass(subNode) === DEFINED_NODES.softbreak) {
                     this.tags = [...this.tags, SOFTBREAK_RULE()];
                 } else {
                     if (subNode.nodes) {
-                        if (this.getClass(subNode) === definedNodes.paragraph) {
+                        if (this.getClass(subNode) === DEFINED_NODES.paragraph) {
                             this.traverseNodes(subNode.nodes, properties);
                             let ooxml = '';
                             for (let xmlTag of this.tags) {
@@ -148,7 +134,7 @@ class ToOOXMLVisitor {
                             this.globalOOXML += ooxml;
                             // Clear all the tags as all nodes of paragraph have been traversed.
                             this.tags = [];
-                        } else if (this.getClass(subNode) === definedNodes.heading) {
+                        } else if (this.getClass(subNode) === DEFINED_NODES.heading) {
                             this.traverseNodes(subNode.nodes, properties);
                             let ooxml = '';
                             for (let xmlTag of this.tags) {

--- a/packages/markdown-docx/src/constants.js
+++ b/packages/markdown-docx/src/constants.js
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const DEFINED_NODES = {
+    computedVariable: 'org.accordproject.ciceromark.ComputedVariable',
+    heading: 'org.accordproject.commonmark.Heading',
+    item: 'org.accordproject.commonmark.Item',
+    list: 'org.accordproject.commonmark.List',
+    listBlock: 'org.accordproject.ciceromark.ListBlock',
+    paragraph: 'org.accordproject.commonmark.Paragraph',
+    softbreak: 'org.accordproject.commonmark.Softbreak',
+    text: 'org.accordproject.commonmark.Text',
+    variable: 'org.accordproject.ciceromark.Variable',
+    emphasize: 'org.accordproject.commonmark.Emph',
+    strong: 'org.accordproject.commonmark.Strong',
+    code: 'org.accordproject.commonmark.Code',
+};
+
+module.exports = { DEFINED_NODES };

--- a/packages/markdown-docx/src/constants.js
+++ b/packages/markdown-docx/src/constants.js
@@ -14,19 +14,21 @@
 
 'use strict';
 
-const DEFINED_NODES = {
-    computedVariable: 'org.accordproject.ciceromark.ComputedVariable',
-    heading: 'org.accordproject.commonmark.Heading',
-    item: 'org.accordproject.commonmark.Item',
-    list: 'org.accordproject.commonmark.List',
-    listBlock: 'org.accordproject.ciceromark.ListBlock',
-    paragraph: 'org.accordproject.commonmark.Paragraph',
-    softbreak: 'org.accordproject.commonmark.Softbreak',
-    text: 'org.accordproject.commonmark.Text',
-    variable: 'org.accordproject.ciceromark.Variable',
-    emphasize: 'org.accordproject.commonmark.Emph',
-    strong: 'org.accordproject.commonmark.Strong',
-    code: 'org.accordproject.commonmark.Code',
+const { NS_PREFIX_CommonMarkModel } = require('@accordproject/markdown-common').CommonMarkModel;
+const { NS_PREFIX_CiceroMarkModel } = require('@accordproject/markdown-cicero').CiceroMarkModel;
+
+const TRANSFORMED_NODES = {
+    code: `${NS_PREFIX_CommonMarkModel}Code`,
+    computedVariable: `${NS_PREFIX_CiceroMarkModel}ComputedVariable`,
+    document: `${NS_PREFIX_CommonMarkModel}Document`,
+    emphasize: `${NS_PREFIX_CommonMarkModel}Emph`,
+    heading: `${NS_PREFIX_CommonMarkModel}Heading`,
+    item: `${NS_PREFIX_CommonMarkModel}Item`,
+    paragraph: `${NS_PREFIX_CommonMarkModel}Paragraph`,
+    softbreak: `${NS_PREFIX_CommonMarkModel}Softbreak`,
+    strong: `${NS_PREFIX_CommonMarkModel}Strong`,
+    text: `${NS_PREFIX_CommonMarkModel}Text`,
+    variable: `${NS_PREFIX_CiceroMarkModel}Variable`,
 };
 
-module.exports = { DEFINED_NODES };
+module.exports = { TRANSFORMED_NODES };


### PR DESCRIPTION
Signed-off-by: K-Kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

Created in relation to the [comment](https://github.com/accordproject/markdown-transform/pull/426#discussion_r665536884).

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Declare `DEFINED_NODES` in a separate file and export.
- <TWO> Use `DEFINED_NODES` in place of class and nodeType.

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`