### PR TITLE
refactor(markdown-docx): remove return variable frequency api

### DIFF
--- a/packages/markdown-docx/src/ToOOXMLVisitor/index.js
+++ b/packages/markdown-docx/src/ToOOXMLVisitor/index.js
@@ -166,13 +166,13 @@ class ToOOXMLVisitor {
      * Transforms the given CiceroMark JSON to OOXML
      *
      * @param {Object} ciceromark CiceroMark JSON to be converted
-     * @returns {object} { Converted OOXML string i.e. CiceroMark->OOXML, Frequency of variables }
+     * @returns {string} OOXML string
      */
     toOOXML(ciceromark) {
         this.traverseNodes(ciceromark, []);
         this.globalOOXML = wrapAroundDefaultDocxTags(this.globalOOXML);
 
-        return { ooxml: this.globalOOXML, counter: this.counter };
+        return this.globalOOXML;
     }
 }
 

--- a/packages/markdown-docx/test/helper.js
+++ b/packages/markdown-docx/test/helper.js
@@ -31,7 +31,7 @@ const checkRoundTripEquality = async filePath => {
     ciceroMark = JSON.parse(ciceroMark);
 
     const ooxmlTransformer = new OOXMLTransformer();
-    const { ooxml } = ooxmlTransformer.toOOXML(ciceroMark);
+    const ooxml = ooxmlTransformer.toOOXML(ciceroMark);
 
     const convertedCiceroMark = ooxmlTransformer.toCiceroMark(ooxml);
     expect(convertedCiceroMark).to.deep.equal(ciceroMark);


### PR DESCRIPTION
Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
Removes the return of `counter` variable when converting to `OOXML`.
Raised as a part of the discussion [here](https://github.com/accordproject/markdown-transform/pull/424#discussion_r673341224)

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Return only `ooxml` as string in `toOOXML` of the `ToOOXMLVisitor.js`

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`