### PR TITLE
fix(CLI) Allow extensions with ES6 modules exports

### DIFF
--- a/packages/markdown-cli/index.js
+++ b/packages/markdown-cli/index.js
@@ -116,6 +116,10 @@ require('yargs')
             let extension = {};
             if (argv.extension) {
                 extension = require(path.resolve(process.cwd(),argv.extension));
+                // To support ES6 "export default"
+                if (extension.default) {
+                    extension = extension.default;
+                }
             }
             parameters.plugin = plugin;
             parameters.template = argv.template;


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

- Allow loading transform extensions in the CLI that have been built with ES6 "export default"

### Description

This means the CLI extension option will allow both:
```javascript
module.exports = {
    format: ...
    transforms: ...
};
```

and

```javascript
export default {
    format: ...
    transforms: ...
};
```

