### PR TITLE
fix(CLI) Do not print result if using --output option

### DIFF
--- a/packages/markdown-cli/index.js
+++ b/packages/markdown-cli/index.js
@@ -136,8 +136,7 @@ require('yargs')
                     if(result) {
                         if(targetFormat.fileFormat !== 'binary') {
                             logger.info('\n'+result);
-                        }
-                        else {
+                        } else {
                             logger.info(`\n<binary ${argv.to} data>`);
                         }
                     }

--- a/packages/markdown-cli/lib/commands.js
+++ b/packages/markdown-cli/lib/commands.js
@@ -149,6 +149,7 @@ class Commands {
 
         if (outputPath) {
             Commands.printFormatToFile(engine,result,finalFormat,outputPath);
+            return Promise.resolve({});
         }
         return Promise.resolve(Commands.printFormatToString(engine,result,finalFormat))
             .then((result) => {


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

- Do not print out the result if `--output` is used

