### PR TITLE
fix(build) Make coverage script generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postinstall": "npm run models:get && lerna bootstrap",
     "models:get": "node ./scripts/external/getExternalModels.js",
     "models:clean": "node ./scripts/external/cleanExternalModels.js",
-    "coverage": "node ./scripts/coverage.js && nyc report -t coverage --cwd . --report-dir coverage --reporter=lcov && cat ./coverage/lcov.info",
+    "coverage": "node ./scripts/coverage.js \"packages/markdown-*\" && nyc report -t coverage --cwd . --report-dir coverage --reporter=lcov && cat ./coverage/lcov.info",
     "pretest": "npm run licchk",
     "test": "lerna exec --ignore dingus -- npm run test:cov",
     "repoclean": "lerna clean",

--- a/scripts/coverage.js
+++ b/scripts/coverage.js
@@ -15,6 +15,8 @@
 
 'use strict';
 
+const globPattern = process.argv[2];
+
 const util = require('util');
 const fs = require('fs');
 const path = require('path');
@@ -30,7 +32,7 @@ function copyFiles(files, destDir) {
     }));
 }
 
-const lcovs = glob.sync('packages/markdown-*').map((dir) => {
+const lcovs = glob.sync(globPattern).map((dir) => {
     const packageName = dir.split('/').pop();
     return {
         source: path.join(dir, 'coverage/coverage-final.json'),


### PR DESCRIPTION
Signed-off-by: jeromesimeon <jeromesimeon@me.com>

### Changes

- Make the `coverage` script generic so it can be used in other projects, passes a glob pattern as parameter

