### PR TITLE
chore(github) - add action to deploy Templatemark Dingus to AWS S3

### DIFF
--- a/.github/workflows/build-and-deploy-dingus.yml
+++ b/.github/workflows/build-and-deploy-dingus.yml
@@ -1,0 +1,55 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: NPM Install
+        if: github.ref == 'refs/heads/master'
+        run: npm install
+
+      - name: NPM Build
+        run: npm run build
+        if: github.ref == 'refs/heads/master'
+
+      - name: Set S3 
+        if: github.ref == 'refs/heads/master'
+        run: |
+            echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
+
+      - name: Deploy to S3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          SOURCE_DIR: 'packages/dingus'
+
+      - name: Invalidate Cloudfront
+        uses: chetan/invalidate-cloudfront-action@master
+        env:
+          DISTRIBUTION: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
+          PATHS: '/*'
+          AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/build-and-deploy-dingus.yml
+++ b/.github/workflows/build-and-deploy-dingus.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build and Deploy Dingus
 
 on:
   push:

--- a/.github/workflows/build-and-deploy-dingus.yml
+++ b/.github/workflows/build-and-deploy-dingus.yml
@@ -28,15 +28,23 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: NPM Install
-        if: github.ref == 'refs/heads/master'
         run: npm install
 
       - name: NPM Build
         run: npm run build
-        if: github.ref == 'refs/heads/master'
+
+      - name: Build Dingus
+        run: |
+            cd packages/dingus
+            mkdir demo
+            scripts/demodata.js > lib/sample.json
+            node_modules/.bin/pug lib/index.pug --pretty --obj lib/sample.json --out demo
+            node_modules/.bin/stylus -u autoprefixer-stylus < lib/index.styl > demo/index.css
+            cp lib/templatemark.css demo/templatemark.css
+            rm -rf lib/sample.json
+            node_modules/.bin/browserify lib/index.js > demo/index.js
 
       - name: Set S3 
-        if: github.ref == 'refs/heads/master'
         run: |
             echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
 
@@ -45,7 +53,7 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
-          SOURCE_DIR: 'packages/dingus'
+          SOURCE_DIR: 'packages/dingus/demo'
 
       - name: Invalidate Cloudfront
         uses: chetan/invalidate-cloudfront-action@master


### PR DESCRIPTION
Creates an GitHub "Action" to build and deploy Templatemark Dingus to AWS S3.

Requires the following "SECRETS" to be specified in GitHub.
```
AWS_ACCESS_KEY_ID: ****
AWS_SECRET_ACCESS_KEY: *****
AWS_REGION : us-east-1
```
Will need to add the following secrets to the repo.
```
AWS_CLOUDFRONT_DISTRIBUTION_ID : E4NC0BLM2QQHM
AWS_S3_BUCKET:  templatemark-dingus.accordproject.org
```
The invalidation is created after each deployment to S3 and can be seen here:
https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/E4NC0BLM2QQHM/invalidations

The S3 Bucket URL for testing is:
http://templatemark-dingus.accordproject.org.s3-website-us-east-1.amazonaws.com/

The CloudFront Distro URL for testing is:
https://defpqedhlibco.cloudfront.net/