### PR TITLE
feat(markdown-transform): add table transforms

### DIFF
--- a/packages/markdown-common/lib/CommonMarkUtils.js
+++ b/packages/markdown-common/lib/CommonMarkUtils.js
@@ -174,6 +174,15 @@ function mkATXHeading(level) {
 }
 
 /**
+ * Create table heading
+ * @param {number} col - the number of columns
+ * @return {string} the markup for the table heading
+ */
+function mkTableHeading(col) {
+    return Array(col).fill('|---------').join('') + '|';
+}
+
+/**
  * Adding escapes for text nodes
  * @param {string} input - unescaped
  * @return {string} escaped
@@ -334,6 +343,7 @@ module.exports.mkNewLine = mkNewLine;
 module.exports.mkPrefix = mkPrefix;
 module.exports.mkSetextHeading = mkSetextHeading;
 module.exports.mkATXHeading = mkATXHeading;
+module.exports.mkTableHeading = mkTableHeading;
 
 module.exports.escapeText = escapeText;
 module.exports.escapeCodeBlock = escapeCodeBlock;

--- a/packages/markdown-common/lib/__snapshots__/CommonMarkTransformer.test.js.snap
+++ b/packages/markdown-common/lib/__snapshots__/CommonMarkTransformer.test.js.snap
@@ -3192,6 +3192,588 @@ Object {
 }
 `;
 
+exports[`markdown converts table.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Header1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Header 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Simple",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Table",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts table_bold.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Syntax",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Description",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Strong",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Bold content",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Title",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts table_code.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Code",
+                      "text": "code block",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Table",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts table_image.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Syntax",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Description",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Strong",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Bold content",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Image",
+                      "destination": "https://docs.accordproject.org/docs/assets/020/template.png",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "ap_logo",
+                        },
+                      ],
+                      "title": "AP triangle",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts table_links.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Link",
+                      "destination": "http://clause.io",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "link",
+                        },
+                      ],
+                      "title": "",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Table",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown converts table_skewed.md to concerto JSON 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Header1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Header 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Simple",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Table",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown converts text.md to concerto JSON 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",
@@ -4164,6 +4746,48 @@ This is second paragraph."
 `;
 
 exports[`to plain text strong.md 1`] = `"This is some text."`;
+
+exports[`to plain text table.md 1`] = `
+"| Header1 | Header 2 |
+|---------|---------|
+| Simple | Table |
+| Paragraph | Text |"
+`;
+
+exports[`to plain text table_bold.md 1`] = `
+"| Syntax | Description |
+|---------|---------|
+| **Bold content** | Title |
+| Paragraph | Text |"
+`;
+
+exports[`to plain text table_code.md 1`] = `
+"| Column1 | Column 2 |
+|---------|---------|
+| \`code block\` | Table |
+| Paragraph | Text |"
+`;
+
+exports[`to plain text table_image.md 1`] = `
+"| Syntax | Description |
+|---------|---------|
+| **Bold content** | ![ap_logo](https://docs.accordproject.org/docs/assets/020/template.png \\"AP triangle\\") |
+| Paragraph | Text |"
+`;
+
+exports[`to plain text table_links.md 1`] = `
+"| Column1 | Column 2 |
+|---------|---------|
+| [link](http://clause.io \\"\\") | Table |
+| Paragraph | Text |"
+`;
+
+exports[`to plain text table_skewed.md 1`] = `
+"| Header1 | Header 2 |
+|---------|---------|
+| Simple | Table |
+| Paragraph | Text |"
+`;
 
 exports[`to plain text text.md 1`] = `"This is some text."`;
 

--- a/packages/markdown-common/lib/fromcommonmarkrules.js
+++ b/packages/markdown-common/lib/fromcommonmarkrules.js
@@ -149,4 +149,43 @@ rules.Document = (visitor,thing,children,parameters,resultString,resultSeq) => {
     resultSeq(parameters,result);
 };
 
+rules.Table = (visitor,thing,children,parameters,resultString,resultSeq) => {
+    const result = [children];
+    resultSeq(parameters,result);
+};
+
+rules.TableBody = (visitor,thing,children,parameters,resultString,resultSeq) => {
+    const result = [children];
+    resultSeq(parameters,result);
+};
+
+rules.TableRow = (visitor,thing,children,parameters,resultString,resultSeq) => {
+    const next1 = '|';
+    const newLine = CommonMarkUtils.mkNewLine(parameters);
+    const result = [children, resultString(next1), newLine];
+    resultSeq(parameters,result);
+};
+
+rules.TableCell = (visitor,thing,children,parameters,resultString,resultSeq) => {
+    const next1 = '|';
+    const next2 = ' ';
+    const result = [resultString(next1),resultString(next2),children, resultString(next2)];
+    resultSeq(parameters,result);
+};
+
+rules.TableHead = (visitor,thing,children,parameters,resultString,resultSeq) => {
+    const col = thing.nodes[0].nodes.length;
+    const next1 = CommonMarkUtils.mkTableHeading(col);
+    const newLine = CommonMarkUtils.mkNewLine(parameters);
+    const result = [children, resultString(next1), resultString(newLine)];
+    resultSeq(parameters,result);
+};
+
+rules.HeaderCell = (visitor,thing,children,parameters,resultString,resultSeq) => {
+    const next1 = '|';
+    const next2 = ' ';
+    const result = [resultString(next1),resultString(next2),children, resultString(next2)];
+    resultSeq(parameters,result);
+};
+
 module.exports = rules;

--- a/packages/markdown-common/lib/tocommonmarkrules.js
+++ b/packages/markdown-common/lib/tocommonmarkrules.js
@@ -243,6 +243,96 @@ const listItemCloseRule = {
     close: true,
 };
 
+const tableOpenRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'Table',
+    leaf: false,
+    open: true,
+    close: false,
+    enter: (node, token, callback) => {},
+};
+
+const tableCloseRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'Table',
+    leaf: false,
+    open: false,
+    close: true,
+};
+
+const tableHeadOpenRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'TableHead',
+    leaf: false,
+    open: true,
+    close: false,
+    enter: (node, token, callback) => {},
+};
+
+const tableHeadCloseRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'TableHead',
+    leaf: false,
+    open: false,
+    close: true,
+};
+
+const tableBodyOpenRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'TableBody',
+    leaf: false,
+    open: true,
+    close: false,
+    enter: (node, token, callback) => {},
+};
+
+const tableBodyCloseRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'TableBody',
+    leaf: false,
+    open: false,
+    close: true,
+};
+
+const tableRowOpenRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'TableRow',
+    leaf: false,
+    open: true,
+    close: false,
+    enter: (node, token, callback) => {},
+};
+
+const tableRowCloseRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'TableRow',
+    leaf: false,
+    open: false,
+    close: true,
+};
+
+const headerCellOpenRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'HeaderCell',
+    leaf: false,
+    open: true,
+    close: false,
+    enter: (node, token, callback) => {},
+};
+
+const headerCellCloseRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'HeaderCell',
+    leaf: false,
+    open: false,
+    close: true,
+};
+
+const tableCellOpenRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'TableCell',
+    leaf: false,
+    open: true,
+    close: false,
+    enter: (node, token, callback) => {},
+};
+
+const tableCellCloseRule = {
+    tag: NS_PREFIX_CommonMarkModel + 'TableCell',
+    leaf: false,
+    open: false,
+    close: true,
+};
+
 const rules = { inlines: {}, blocks: {}};
 rules.inlines.text = textRule;
 rules.inlines.code_inline = codeInlineRule;
@@ -273,5 +363,17 @@ rules.blocks.ordered_list_open = orderedListOpenRule;
 rules.blocks.ordered_list_close = orderedListCloseRule;
 rules.blocks.list_item_open = listItemOpenRule;
 rules.blocks.list_item_close = listItemCloseRule;
+rules.blocks.table_open = tableOpenRule;
+rules.blocks.table_close = tableCloseRule;
+rules.blocks.thead_open = tableHeadOpenRule;
+rules.blocks.thead_close = tableHeadCloseRule;
+rules.blocks.tbody_open = tableBodyOpenRule;
+rules.blocks.tbody_close = tableBodyCloseRule;
+rules.blocks.tr_open = tableRowOpenRule;
+rules.blocks.tr_close = tableRowCloseRule;
+rules.blocks.th_open = headerCellOpenRule;
+rules.blocks.th_close = headerCellCloseRule;
+rules.blocks.td_open = tableCellOpenRule;
+rules.blocks.td_close = tableCellCloseRule;
 
 module.exports = rules;

--- a/packages/markdown-common/test/data/table.md
+++ b/packages/markdown-common/test/data/table.md
@@ -1,0 +1,4 @@
+| Header1     | Header 2    |
+| ----------- | ----------- |
+| Simple      | Table       | 
+| Paragraph   | Text        |

--- a/packages/markdown-common/test/data/table_bold.md
+++ b/packages/markdown-common/test/data/table_bold.md
@@ -1,0 +1,4 @@
+| Syntax           | Description |
+| ---------------- | ----------- |
+| **Bold content** | Title       | 
+| Paragraph        | Text        |

--- a/packages/markdown-common/test/data/table_code.md
+++ b/packages/markdown-common/test/data/table_code.md
@@ -1,0 +1,4 @@
+| Column1     | Column 2    |
+| ----------- | ----------- |
+| `code block`      | Table       | 
+| Paragraph   | Text        |

--- a/packages/markdown-common/test/data/table_image.md
+++ b/packages/markdown-common/test/data/table_image.md
@@ -1,0 +1,4 @@
+| Syntax           | Description |
+| ---------------- | ----------- |
+| **Bold content** | ![ap_logo](https://docs.accordproject.org/docs/assets/020/template.png "AP triangle")      | 
+| Paragraph        | Text        |

--- a/packages/markdown-common/test/data/table_links.md
+++ b/packages/markdown-common/test/data/table_links.md
@@ -1,0 +1,4 @@
+| Column1     | Column 2    |
+| ----------- | ----------- |
+| [link](http://clause.io) | Table       | 
+| Paragraph   | Text        |

--- a/packages/markdown-common/test/data/table_skewed.md
+++ b/packages/markdown-common/test/data/table_skewed.md
@@ -1,0 +1,4 @@
+| Header1     | Header 2     |
+| ----------- | ----------- |
+| Simple     | Table       | 
+| Paragraph     | Text        |

--- a/packages/markdown-html/src/ToHtmlStringVisitor.js
+++ b/packages/markdown-html/src/ToHtmlStringVisitor.js
@@ -205,6 +205,32 @@ class ToHtmlStringVisitor {
         case 'Item':
             parameters.result += `<li>${ToHtmlStringVisitor.visitChildren(this, thing)}</li>\n`;
             break;
+
+        case 'Table':
+            parameters.result += '\n';
+            parameters.result += `<table>${ToHtmlStringVisitor.visitChildren(this, thing)}\n</table>\n`;
+            break;
+
+        case 'TableHead':
+            parameters.result += `\n<thead>${ToHtmlStringVisitor.visitChildren(this,thing)}\n</thead>`;
+            break;
+
+        case 'TableBody':
+            parameters.result += `\n<tbody>${ToHtmlStringVisitor.visitChildren(this,thing)}\n</tbody>`;
+            break;
+
+        case 'TableRow':
+            parameters.result += `\n<tr>\n${ToHtmlStringVisitor.visitChildren(this,thing)}</tr>`;
+            break;
+
+        case 'TableCell':
+            parameters.result += `<td>${ToHtmlStringVisitor.visitChildren(this,thing)}</td>\n`;
+            break;
+
+        case 'HeaderCell':
+            parameters.result += `<th>${ToHtmlStringVisitor.visitChildren(this,thing)}</th>\n`;
+            break;
+
         case 'Document':
             parameters.result += `<html>\n<head><meta charset="UTF-8"></head>\n<body>\n<div class="document">\n${ToHtmlStringVisitor.visitChildren(this, thing)}</div>\n</body>\n</html>`;
             break;

--- a/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
+++ b/packages/markdown-html/src/__snapshots__/HtmlTransformer.test.js.snap
@@ -1712,6 +1712,296 @@ exports[`markdown <-> html converts strong.md to html 2`] = `
 </html>"
 `;
 
+exports[`markdown <-> html converts table.md to html 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Header1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Header 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Simple",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Table",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown <-> html converts table.md to html 2`] = `
+"<html>
+<head><meta charset=\\"UTF-8\\"></head>
+<body>
+<div class=\\"document\\">
+
+<table>
+<thead>
+<tr>
+<th>Header1</th>
+<th>Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Simple</td>
+<td>Table</td>
+</tr>
+<tr>
+<td>Paragraph</td>
+<td>Text</td>
+</tr>
+</tbody>
+</table>
+</div>
+</body>
+</html>"
+`;
+
+exports[`markdown <-> html converts table_complex.md to html 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Code",
+                      "text": "code block",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Image",
+                      "destination": "https://docs.accordproject.org/docs/assets/020/template.png",
+                      "nodes": Array [],
+                      "title": "AP triangle",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Strong",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Bold content",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Link",
+                      "destination": "http://clause.io",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "link",
+                        },
+                      ],
+                      "title": "",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Emph",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Italics",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown <-> html converts table_complex.md to html 2`] = `
+"<html>
+<head><meta charset=\\"UTF-8\\"></head>
+<body>
+<div class=\\"document\\">
+
+<table>
+<thead>
+<tr>
+<th>Column1</th>
+<th>Column 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>code block</code></td>
+<td><img src=\\"https://docs.accordproject.org/docs/assets/020/template.png\\" title=\\"AP triangle\\"/></td>
+</tr>
+<tr>
+<td>Paragraph</td>
+<td><strong>Bold content</strong></td>
+</tr>
+<tr>
+<td><a href=\\"http://clause.io\\" title=>link</a></td>
+<td><em>Italics</em></td>
+</tr>
+</tbody>
+</table>
+</div>
+</body>
+</html>"
+`;
+
 exports[`markdown <-> html converts text.md to html 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",

--- a/packages/markdown-html/src/rules.js
+++ b/packages/markdown-html/src/rules.js
@@ -500,6 +500,47 @@ const HTML_BLOCK_RULE = {
     }
 };
 
+const TABLE_RULE = {
+    deserialize(el, next, ignoreSpace) {
+        if (el.tagName && el.tagName.toLowerCase() === 'table') {
+            return {
+                $class: `${NS_PREFIX_CommonMarkModel}Table`,
+                nodes: next(el.childNodes),
+            };
+        }
+        if (el.tagName && el.tagName.toLowerCase() === 'thead') {
+            return {
+                $class: `${NS_PREFIX_CommonMarkModel}TableHead`,
+                nodes: next(el.childNodes),
+            };
+        }
+        if (el.tagName && el.tagName.toLowerCase() === 'tbody') {
+            return {
+                $class: `${NS_PREFIX_CommonMarkModel}TableBody`,
+                nodes: next(el.childNodes),
+            };
+        }
+        if (el.tagName && el.tagName.toLowerCase() === 'tr') {
+            return {
+                $class: `${NS_PREFIX_CommonMarkModel}TableRow`,
+                nodes: next(el.childNodes),
+            };
+        }
+        if (el.tagName && el.tagName.toLowerCase() === 'th') {
+            return {
+                $class: `${NS_PREFIX_CommonMarkModel}HeaderCell`,
+                nodes: next(el.childNodes),
+            };
+        }
+        if (el.tagName && el.tagName.toLowerCase() === 'td') {
+            return {
+                $class: `${NS_PREFIX_CommonMarkModel}TableCell`,
+                nodes: next(el.childNodes),
+            };
+        }
+    },
+};
+
 const rules = [
     LIST_RULE,
     PARAGRAPH_RULE,
@@ -520,7 +561,8 @@ const rules = [
     TEXT_RULE,
     HTML_INLINE_RULE,
     HTML_BLOCK_RULE,
-    IMAGE_RULE
+    IMAGE_RULE,
+    TABLE_RULE
 ];
 
 

--- a/packages/markdown-html/test/data/markdown/table.md
+++ b/packages/markdown-html/test/data/markdown/table.md
@@ -1,0 +1,4 @@
+| Header1     | Header 2    |
+| ----------- | ----------- |
+| Simple      | Table       | 
+| Paragraph   | Text        |

--- a/packages/markdown-html/test/data/markdown/table_complex.md
+++ b/packages/markdown-html/test/data/markdown/table_complex.md
@@ -1,0 +1,5 @@
+| Column1     | Column 2    |
+| ----------- | ----------- |
+| `code block`      | ![](https://docs.accordproject.org/docs/assets/020/template.png "AP triangle")       | 
+| Paragraph   | **Bold content**     |
+| [link](http://clause.io) | *Italics* |

--- a/packages/markdown-pdf/src/commonmarkrules.js
+++ b/packages/markdown-pdf/src/commonmarkrules.js
@@ -102,6 +102,24 @@ rules.ListBlock = (visitor, thing, children, parameters) => {
 rules.List = (visitor, thing, children, parameters) => {
     parameters.result[thing.type === 'ordered' ? 'ol' : 'ul'] = children;
 };
+rules.Table = (visitor, thing, children, parameters) => {
+    parameters.result.table = {'body': children};
+};
+rules.TableHead = (visitor, thing, children, parameters) => {
+    parameters.result = children;
+};
+rules.TableBody = (visitor, thing, children, parameters) => {
+    parameters.result = children;
+};
+rules.TableRow = (visitor, thing, children, parameters) => {
+    parameters.result = [children];
+};
+rules.HeaderCell = (visitor, thing, children, parameters) => {
+    parameters.result.stack = children;
+};
+rules.TableCell = (visitor, thing, children, parameters) => {
+    parameters.result.stack = children;
+};
 rules.Document = (visitor, thing, children, parameters) => {
     parameters.result.content = children;
 };

--- a/packages/markdown-pdf/src/pdfmakeutil.js
+++ b/packages/markdown-pdf/src/pdfmakeutil.js
@@ -135,6 +135,11 @@ const defaultStyles = {
     },
     background: {
         color: 'white'
+    },
+    HeaderCell: {
+        fontSize: 13,
+        bold: true,
+        color: 'black'
     }
 };
 

--- a/packages/markdown-pdf/test/data/tables.md
+++ b/packages/markdown-pdf/test/data/tables.md
@@ -1,0 +1,14 @@
+This is a simple table:
+
+| Header1     | Header 2    |
+| ----------- | ----------- |
+| Simple      | Table       | 
+| Paragraph   | Text        |
+
+This is a complex table:
+
+| Column1     | Column 2    |
+| ----------- | ----------- |
+| `code block`      | ![](https://docs.accordproject.org/docs/assets/020/template.png "AP triangle")       | 
+| Paragraph   | **Bold content**     |
+| [link](http://clause.io) | *Italics* |

--- a/packages/markdown-slate/lib/__snapshots__/SlateTransformer.test.js.snap
+++ b/packages/markdown-slate/lib/__snapshots__/SlateTransformer.test.js.snap
@@ -10127,6 +10127,785 @@ Object {
 }
 `;
 
+exports[`markdown <-> slate converts table.json to and from Markdown 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Simple",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Table",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown <-> slate converts table.json to and from Markdown 2`] = `
+"| Column 1    | Column 2    |
+| ----------- | ----------- |
+| Simple      | Table       | 
+| Paragraph   | Text        |"
+`;
+
+exports[`markdown <-> slate converts table.json to and from Markdown 3`] = `
+Object {
+  "document": Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Column 1",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "header_cell",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Column 2",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "header_cell",
+                  },
+                ],
+                "data": Object {},
+                "object": "block",
+                "type": "table_row",
+              },
+            ],
+            "data": Object {},
+            "object": "block",
+            "type": "table_head",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Simple",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Table",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                ],
+                "data": Object {},
+                "object": "block",
+                "type": "table_row",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Paragraph",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Text",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                ],
+                "data": Object {},
+                "object": "block",
+                "type": "table_row",
+              },
+            ],
+            "data": Object {},
+            "object": "block",
+            "type": "table_body",
+          },
+        ],
+        "data": Object {},
+        "object": "block",
+        "type": "table",
+      },
+    ],
+    "data": Object {},
+    "object": "document",
+  },
+}
+`;
+
+exports[`markdown <-> slate converts table.json to and from Markdown 4`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Simple",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Table",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Text",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown <-> slate converts table_complex.json to and from Markdown 1`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Code",
+                      "text": "code block",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Image",
+                      "destination": "https://docs.accordproject.org/docs/assets/020/template.png",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "",
+                        },
+                      ],
+                      "title": "AP triangle",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Strong",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Bold content",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Link",
+                      "destination": "http://clause.io",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "link",
+                        },
+                      ],
+                      "title": "",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Emph",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Italics",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
+exports[`markdown <-> slate converts table_complex.json to and from Markdown 2`] = `
+"| Column 1    | Column 2    |
+| ----------- | ----------- |
+| \`code block\`      | ![](https://docs.accordproject.org/docs/assets/020/template.png \\"AP triangle\\")       | 
+| Paragraph   | **Bold content**     |
+| [link](http://clause.io) | *Italics* |"
+`;
+
+exports[`markdown <-> slate converts table_complex.json to and from Markdown 3`] = `
+Object {
+  "document": Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Column 1",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "header_cell",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Column 2",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "header_cell",
+                  },
+                ],
+                "data": Object {},
+                "object": "block",
+                "type": "table_row",
+              },
+            ],
+            "data": Object {},
+            "object": "block",
+            "type": "table_head",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "code": true,
+                        "object": "text",
+                        "text": "code block",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "object": "text",
+                            "text": "",
+                          },
+                        ],
+                        "data": Object {
+                          "href": "https://docs.accordproject.org/docs/assets/020/template.png",
+                          "title": "AP triangle",
+                        },
+                        "object": "inline",
+                        "type": "image",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                ],
+                "data": Object {},
+                "object": "block",
+                "type": "table_row",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "Paragraph",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "bold": true,
+                        "object": "text",
+                        "text": "Bold content",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                ],
+                "data": Object {},
+                "object": "block",
+                "type": "table_row",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "object": "text",
+                        "text": "",
+                      },
+                      Object {
+                        "children": Array [
+                          Object {
+                            "object": "text",
+                            "text": "link",
+                          },
+                        ],
+                        "data": Object {
+                          "href": "http://clause.io",
+                          "title": "",
+                        },
+                        "object": "inline",
+                        "type": "link",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "italic": true,
+                        "object": "text",
+                        "text": "Italics",
+                      },
+                    ],
+                    "data": Object {},
+                    "object": "block",
+                    "type": "table_cell",
+                  },
+                ],
+                "data": Object {},
+                "object": "block",
+                "type": "table_row",
+              },
+            ],
+            "data": Object {},
+            "object": "block",
+            "type": "table_body",
+          },
+        ],
+        "data": Object {},
+        "object": "block",
+        "type": "table",
+      },
+    ],
+    "data": Object {},
+    "object": "document",
+  },
+}
+`;
+
+exports[`markdown <-> slate converts table_complex.json to and from Markdown 4`] = `
+Object {
+  "$class": "org.accordproject.commonmark.Document",
+  "nodes": Array [
+    Object {
+      "$class": "org.accordproject.commonmark.Table",
+      "nodes": Array [
+        Object {
+          "$class": "org.accordproject.commonmark.TableHead",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 1",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.HeaderCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Column 2",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        Object {
+          "$class": "org.accordproject.commonmark.TableBody",
+          "nodes": Array [
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Code",
+                      "text": "code block",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Image",
+                      "destination": "https://docs.accordproject.org/docs/assets/020/template.png",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "",
+                        },
+                      ],
+                      "title": "AP triangle",
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Text",
+                      "text": "Paragraph",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Strong",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Bold content",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            Object {
+              "$class": "org.accordproject.commonmark.TableRow",
+              "nodes": Array [
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Link",
+                      "destination": "http://clause.io",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "link",
+                        },
+                      ],
+                      "title": "",
+                    },
+                  ],
+                },
+                Object {
+                  "$class": "org.accordproject.commonmark.TableCell",
+                  "nodes": Array [
+                    Object {
+                      "$class": "org.accordproject.commonmark.Emph",
+                      "nodes": Array [
+                        Object {
+                          "$class": "org.accordproject.commonmark.Text",
+                          "text": "Italics",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "xmlns": "http://commonmark.org/xml/1.0",
+}
+`;
+
 exports[`markdown <-> slate converts text.json to and from Markdown 1`] = `
 Object {
   "$class": "org.accordproject.commonmark.Document",

--- a/packages/markdown-slate/lib/commonmarkfromslaterules.js
+++ b/packages/markdown-slate/lib/commonmarkfromslaterules.js
@@ -78,5 +78,23 @@ rules.ol_list = (node,processNodes) => {
 rules.ul_list = (node,processNodes) => {
     return {$class : `${NS_PREFIX_CommonMarkModel}List`, type: 'bullet', delimiter: node.data.delimiter, start: node.data.start, tight: node.data.tight, nodes: []};
 };
+rules.table = (node, processNodes) => {
+    return { $class: `${NS_PREFIX_CommonMarkModel}Table`, nodes: [] };
+};
+rules.table_head = (node, processNodes) => {
+    return { $class: `${NS_PREFIX_CommonMarkModel}TableHead`, nodes: [] };
+};
+rules.table_body = (node, processNodes) => {
+    return { $class: `${NS_PREFIX_CommonMarkModel}TableBody`, nodes: [] };
+};
+rules.table_row = (node, processNodes) => {
+    return { $class: `${NS_PREFIX_CommonMarkModel}TableRow`, nodes: [] };
+};
+rules.table_cell = (node, processNodes) => {
+    return { $class: `${NS_PREFIX_CommonMarkModel}TableCell`, nodes: [] };
+};
+rules.header_cell = (node, processNodes) => {
+    return { $class: `${NS_PREFIX_CommonMarkModel}HeaderCell`, nodes: [] };
+};
 
 module.exports = rules;

--- a/packages/markdown-slate/lib/commonmarktoslaterules.js
+++ b/packages/markdown-slate/lib/commonmarktoslaterules.js
@@ -174,5 +174,58 @@ rules.Document = (thing,processChildren,parameters) => {
         data : {}
     };
 };
+rules.Table = (thing, processChildren, parameters) => {
+    return {
+        object: 'block',
+        type: 'table',
+        data: {},
+        children: processChildren(thing, 'nodes', parameters),
+    };
+};
+
+rules.TableHead = (thing, processChildren, parameters) => {
+    return {
+        object: 'block',
+        type: 'table_head',
+        data: {},
+        children: processChildren(thing, 'nodes', parameters),
+    };
+};
+
+rules.TableBody = (thing, processChildren, parameters) => {
+    return {
+        object: 'block',
+        type: 'table_body',
+        data: {},
+        children: processChildren(thing, 'nodes', parameters),
+    };
+};
+
+rules.TableRow = (thing, processChildren, parameters) => {
+    return {
+        object: 'block',
+        type: 'table_row',
+        data: {},
+        children: processChildren(thing, 'nodes', parameters),
+    };
+};
+
+rules.TableCell = (thing, processChildren, parameters) => {
+    return {
+        object: 'block',
+        type: 'table_cell',
+        data: {},
+        children: processChildren(thing, 'nodes', parameters),
+    };
+};
+
+rules.HeaderCell = (thing, processChildren, parameters) => {
+    return {
+        object: 'block',
+        type: 'header_cell',
+        data: {},
+        children: processChildren(thing, 'nodes', parameters),
+    };
+};
 
 module.exports = rules;

--- a/packages/markdown-slate/test/data/markdown/table.json
+++ b/packages/markdown-slate/test/data/markdown/table.json
@@ -1,0 +1,116 @@
+{
+  "document": {
+    "object": "document",
+    "data": {},
+    "children": [
+      {
+        "object": "block",
+        "type": "table",
+        "data": {},
+        "children": [
+          {
+            "object": "block",
+            "type": "table_head",
+            "data": {},
+            "children": [
+              {
+                "object": "block",
+                "type": "table_row",
+                "data": {},
+                "children": [
+                  {
+                    "object": "block",
+                    "type": "header_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Column 1"
+                      }
+                    ]
+                  },
+                  {
+                    "object": "block",
+                    "type": "header_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Column 2"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "object": "block",
+            "type": "table_body",
+            "data": {},
+            "children": [
+              {
+                "object": "block",
+                "type": "table_row",
+                "data": {},
+                "children": [
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Simple"
+                      }
+                    ]
+                  },
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Table"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "object": "block",
+                "type": "table_row",
+                "data": {},
+                "children": [
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Paragraph"
+                      }
+                    ]
+                  },
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Text"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/markdown-slate/test/data/markdown/table.md
+++ b/packages/markdown-slate/test/data/markdown/table.md
@@ -1,0 +1,4 @@
+| Column 1    | Column 2    |
+| ----------- | ----------- |
+| Simple      | Table       | 
+| Paragraph   | Text        |

--- a/packages/markdown-slate/test/data/markdown/table_complex.json
+++ b/packages/markdown-slate/test/data/markdown/table_complex.json
@@ -1,0 +1,176 @@
+{
+  "document": {
+    "object": "document",
+    "data": {},
+    "children": [
+      {
+        "object": "block",
+        "type": "table",
+        "data": {},
+        "children": [
+          {
+            "object": "block",
+            "type": "table_head",
+            "data": {},
+            "children": [
+              {
+                "object": "block",
+                "type": "table_row",
+                "data": {},
+                "children": [
+                  {
+                    "object": "block",
+                    "type": "header_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Column 1"
+                      }
+                    ]
+                  },
+                  {
+                    "object": "block",
+                    "type": "header_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Column 2"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "object": "block",
+            "type": "table_body",
+            "data": {},
+            "children": [
+              {
+                "object": "block",
+                "type": "table_row",
+                "data": {},
+                "children": [
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "code block",
+                        "code": true
+                      }
+                    ]
+                  },
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": ""
+                      },
+                      {
+                        "object": "inline",
+                        "type": "image",
+                        "data": {
+                          "href": "https://docs.accordproject.org/docs/assets/020/template.png",
+                          "title": "AP triangle"
+                        },
+                        "children": [
+                          {
+                            "object": "text",
+                            "text": ""
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "object": "block",
+                "type": "table_row",
+                "data": {},
+                "children": [
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Paragraph"
+                      }
+                    ]
+                  },
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Bold content",
+                        "bold": true
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "object": "block",
+                "type": "table_row",
+                "data": {},
+                "children": [
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": ""
+                      },
+                      {
+                        "object": "inline",
+                        "type": "link",
+                        "data": {
+                          "href": "http://clause.io",
+                          "title": ""
+                        },
+                        "children": [
+                          {
+                            "object": "text",
+                            "text": "link"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "object": "block",
+                    "type": "table_cell",
+                    "data": {},
+                    "children": [
+                      {
+                        "object": "text",
+                        "text": "Italics",
+                        "italic": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/markdown-slate/test/data/markdown/table_complex.md
+++ b/packages/markdown-slate/test/data/markdown/table_complex.md
@@ -1,0 +1,5 @@
+| Column 1    | Column 2    |
+| ----------- | ----------- |
+| `code block`      | ![](https://docs.accordproject.org/docs/assets/020/template.png "AP triangle")       | 
+| Paragraph   | **Bold content**     |
+| [link](http://clause.io) | *Italics* |

--- a/scripts/external/models.json
+++ b/scripts/external/models.json
@@ -3,7 +3,7 @@
     "models": [
         { "name": "CommonMarkModel",
           "namespace" : "org.accordproject.commonmark",
-          "from": "https://models.accordproject.org/markdown/commonmark@0.2.0.cto",
+          "from": "https://models.accordproject.org/markdown/commonmark@0.4.0.cto",
           "js": "packages/markdown-common/lib/externalModels" },
         { "name": "ConcertoMetaModel",
           "namespace" : "concerto.metamodel",
@@ -11,11 +11,11 @@
           "js": "packages/markdown-cicero/lib/externalModels" },
         { "name": "CiceroMarkModel",
           "namespace" : "org.accordproject.ciceromark",
-          "from": "https://models.accordproject.org/markdown/ciceromark@0.3.2.cto",
+          "from": "https://models.accordproject.org/markdown/ciceromark@0.3.3.cto",
           "js": "packages/markdown-cicero/lib/externalModels" },
         { "name": "TemplateMarkModel",
           "namespace" : "org.accordproject.templatemark",
-          "from": "https://models.accordproject.org/markdown/templatemark@0.1.2.cto",
+          "from": "https://models.accordproject.org/markdown/templatemark@0.1.3.cto",
           "js": "packages/markdown-template/lib/externalModels" }
     ]
 }


### PR DESCRIPTION
Signed-off-by: TC5022 <tanyac5022002@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> This is a WIP PR to add table extension in various packages of markdown-transform
- <TWO>  Currently the changes reflect transformations in common mark DOM, HTML, the slate DOM and PDF

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE> First we will have to merge the new [table models for commonmark and ciceromark](https://github.com/accordproject/models/pull/159) for these changes to be successful.
- <TWO>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`