### PR TITLE
Fix HTML rendering of relationship variables in CiceroMark

### DIFF
--- a/packages/markdown-html/src/HtmlTransformer.test.js
+++ b/packages/markdown-html/src/HtmlTransformer.test.js
@@ -121,3 +121,63 @@ describe('ciceromark <-> html', () => {
         });
     });
 });
+
+describe('renderVariableValue - relationship variables', () => {
+    it('extracts identifier from a quoted resource URI value', () => {
+        const ciceroMarkJson = {
+            '$class': 'org.accordproject.commonmark@0.5.0.Document',
+            'xmlns': 'http://commonmark.org/xml/1.0',
+            'nodes': [{
+                '$class': 'org.accordproject.commonmark@0.5.0.Paragraph',
+                'nodes': [{
+                    '$class': 'org.accordproject.ciceromark@0.6.0.Variable',
+                    'value': '"resource:org.accordproject.organization@0.2.0.Organization#Party A"',
+                    'identifiedBy': 'identifier',
+                    'name': 'buyer',
+                    'elementType': 'org.accordproject.organization@0.2.0.Organization'
+                }]
+            }]
+        };
+        const html = htmlTransformer.toHtml(ciceroMarkJson);
+        expect(html).toContain('>Party A<');
+        expect(html).not.toContain('resource:');
+    });
+
+    it('leaves primitive variable values unchanged', () => {
+        const ciceroMarkJson = {
+            '$class': 'org.accordproject.commonmark@0.5.0.Document',
+            'xmlns': 'http://commonmark.org/xml/1.0',
+            'nodes': [{
+                '$class': 'org.accordproject.commonmark@0.5.0.Paragraph',
+                'nodes': [{
+                    '$class': 'org.accordproject.ciceromark@0.6.0.Variable',
+                    'value': '"Widgets"',
+                    'name': 'deliverable',
+                    'elementType': 'String'
+                }]
+            }]
+        };
+        const html = htmlTransformer.toHtml(ciceroMarkJson);
+        expect(html).toContain('>"Widgets"<');
+    });
+
+    it('handles bare (unquoted) resource URI values', () => {
+        const ciceroMarkJson = {
+            '$class': 'org.accordproject.commonmark@0.5.0.Document',
+            'xmlns': 'http://commonmark.org/xml/1.0',
+            'nodes': [{
+                '$class': 'org.accordproject.commonmark@0.5.0.Paragraph',
+                'nodes': [{
+                    '$class': 'org.accordproject.ciceromark@0.6.0.Variable',
+                    'value': 'resource:org.accordproject.organization@0.2.0.Organization#Party B',
+                    'identifiedBy': 'identifier',
+                    'name': 'seller',
+                    'elementType': 'org.accordproject.organization@0.2.0.Organization'
+                }]
+            }]
+        };
+        const html = htmlTransformer.toHtml(ciceroMarkJson);
+        expect(html).toContain('>Party B<');
+        expect(html).not.toContain('resource:');
+    });
+});

--- a/packages/markdown-html/src/ToHtmlStringVisitor.js
+++ b/packages/markdown-html/src/ToHtmlStringVisitor.js
@@ -13,6 +13,30 @@
  */
 
 'use strict';
+/**
+ * Converts a markdown node to an HTML string.
+ *
+ * @param {Object} thing - Markdown AST node
+ * @returns {string} HTML representation
+ */
+function renderVariableValue(thing) {
+    // Handle relationship types (e.g. Party)
+    if (
+        thing.elementType &&
+        thing.elementType.startsWith('org.accordproject.party@') &&
+        typeof thing.value === 'string'
+    ) {
+        // Remove quotes if present
+        const unquoted = thing.value.replace(/^"(.*)"$/, '$1');
+
+        // Extract identifier after #
+        const parts = unquoted.split('#');
+        return parts.length > 1 ? parts[1] : unquoted;
+    }
+
+    // Default behavior
+    return thing.value;
+}
 
 // const CiceroMarkTransformer = require('@accordproject/markdown-cicero').CiceroMarkTransformer;
 
@@ -81,7 +105,8 @@ class ToHtmlStringVisitor {
             if (thing.identifiedBy) {
                 attributes += ` identifiedBy="${thing.identifiedBy}"`;
             }
-            parameters.result += `<span ${attributes}>${thing.value}</span>`;
+            parameters.result += `<span ${attributes}>${renderVariableValue(thing)}</span>`;
+
         }
             break;
         case 'FormattedVariable': {
@@ -92,7 +117,8 @@ class ToHtmlStringVisitor {
             if (thing.identifiedBy) {
                 attributes += ` identifiedBy="${thing.identifiedBy}"`;
             }
-            parameters.result += `<span ${attributes}>${thing.value}</span>`;
+            parameters.result += `<span ${attributes}>${renderVariableValue(thing)}</span>`;
+
         }
             break;
         case 'EnumVariable': {
@@ -104,7 +130,8 @@ class ToHtmlStringVisitor {
             if (thing.identifiedBy) {
                 attributes += ` identifiedBy="${thing.identifiedBy}"`;
             }
-            parameters.result += `<span ${attributes}>${thing.value}</span>`;
+            parameters.result += `<span ${attributes}>${renderVariableValue(thing)}</span>`;
+
         }
             break;
         case 'Conditional':

--- a/packages/markdown-html/src/ToHtmlStringVisitor.js
+++ b/packages/markdown-html/src/ToHtmlStringVisitor.js
@@ -14,8 +14,13 @@
 
 'use strict';
 
-// identifiedBy is the Concerto marker for relationship/reference types regardless of namespace.
-// When the value is a full resource URI (resource:namespace#identifier), extract just the identifier.
+/**
+ * Returns the display value for a variable node.
+ * For relationship types (identifiedBy is set), strips the resource URI scheme
+ * (resource:namespace#identifier) and returns just the identifier.
+ * @param {object} thing - the variable node
+ * @returns {string} the display value
+ */
 function renderVariableValue(thing) {
     if (thing.identifiedBy && typeof thing.value === 'string') {
         const unquoted = thing.value.replace(/^"(.*)"$/s, '$1');

--- a/packages/markdown-html/src/ToHtmlStringVisitor.js
+++ b/packages/markdown-html/src/ToHtmlStringVisitor.js
@@ -13,28 +13,16 @@
  */
 
 'use strict';
-/**
- * Converts a markdown node to an HTML string.
- *
- * @param {Object} thing - Markdown AST node
- * @returns {string} HTML representation
- */
+
+// identifiedBy is the Concerto marker for relationship/reference types regardless of namespace.
+// When the value is a full resource URI (resource:namespace#identifier), extract just the identifier.
 function renderVariableValue(thing) {
-    // Handle relationship types (e.g. Party)
-    if (
-        thing.elementType &&
-        thing.elementType.startsWith('org.accordproject.party@') &&
-        typeof thing.value === 'string'
-    ) {
-        // Remove quotes if present
-        const unquoted = thing.value.replace(/^"(.*)"$/, '$1');
-
-        // Extract identifier after #
-        const parts = unquoted.split('#');
-        return parts.length > 1 ? parts[1] : unquoted;
+    if (thing.identifiedBy && typeof thing.value === 'string') {
+        const unquoted = thing.value.replace(/^"(.*)"$/s, '$1');
+        if (unquoted.startsWith('resource:') && unquoted.includes('#')) {
+            return unquoted.split('#').pop();
+        }
     }
-
-    // Default behavior
     return thing.value;
 }
 


### PR DESCRIPTION
# Fix HTML rendering of relationship variables in CiceroMark

Related to accordproject/template-playground#13 

### Summary
Relationship-typed CiceroMark variables were rendered in HTML as quoted
`resource:` strings instead of a readable identifier. This PR fixes the
HTML rendering logic so relationship variables display correctly.[TemplateMark not rendering relationships "resource" data  #13]


### Changes
- Update `ToHtmlStringVisitor` to detect relationship variables via `elementType`
- Render a clean relationship identifier instead of the raw serialized value
- Preserve existing rendering behavior for primitive variable types

### Flags
- No breaking changes
- Change is limited to HTML rendering only (CiceroMark JSON unchanged)

### Screenshots or Video
Not applicable — behavior verified via existing HtmlTransformer test suite.

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option of git commit
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `fork:branchname`
