### PR TITLE
fix: update broken CI badge to use GitHub Actions workflow URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 
 <p align="center">
-  <a href="https://github.com/accordproject/markdown-transform/actions?query=workflow%3Apublish"><img src="https://github.com/accordproject/markdown-transform/workflows/build/badge.svg?branch=main" alt="Build Status"></a>
+  <a href="https://github.com/accordproject/markdown-transform/actions/workflows/build.yml"><img src="https://github.com/accordproject/markdown-transform/actions/workflows/build.yml/badge.svg" alt="Build Status"></a>
   <a href="https://coveralls.io/github/accordproject/markdown-transform?branch=main"><img src="https://coveralls.io/repos/github/accordproject/markdown-transform/badge.svg?branch=main" alt="Coverage Status"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/accordproject/markdown-transform?color=bright-green" alt="GitHub license"></a>
   <a href="https://www.npmjs.com/package/@accordproject/markdown-cli"><img src="https://img.shields.io/npm/dm/@accordproject/markdown-cli" alt="downloads"></a>


### PR DESCRIPTION
# Closes #N/A #

### Changes
- Updated the "Build Status" badge in [README.md](cci:7://file:///c:/Users/Lenovo/markdown-transform/README.md:0:0-0:0) to point to the correct [build.yml](cci:7://file:///c:/Users/Lenovo/markdown-transform/.github/workflows/build.yml:0:0-0:0) GitHub Actions workflow.

### Flags
- None

### Screenshots 

### BEFORE
<img width="1113" height="374" alt="Screenshot 2026-01-18 145805" src="https://github.com/user-attachments/assets/48cc3b07-7623-4ade-bcd5-6dd13e01d08e" />

### AFTER
<img width="1158" height="262" alt="Screenshot 2026-01-18 150800" src="https://github.com/user-attachments/assets/aa0b2d5f-8980-4440-9578-1702fe593617" />

### Related Issues
- None

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/main/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `main` from `fix/ci-badge`