### PR TITLE
Handle empty inline markdown-it token arrays safely

### DIFF
--- a/packages/markdown-common/lib/FromMarkdownIt.js
+++ b/packages/markdown-common/lib/FromMarkdownIt.js
@@ -77,6 +77,11 @@ class FromMarkdownIt {
      * @param {*[]} stack - the stack of constructed nodes
      */
     static inlineToCommonMark(rules,tokens,stack) {
+        if(!Array.isArray(tokens)  || tokens.length===0)
+            return{
+              '$class': `${CommonMarkModel.NAMESPACE}.Inline`,
+              'nodes': [],        
+            }
         const rootNode = {
             '$class': `${CommonMarkModel.NAMESPACE}.Inline`,
             'nodes': [],


### PR DESCRIPTION
Hi, I’m Isha.

This PR improves robustness of inline markdown-it processing by safely
handling empty or missing inline token arrays, preventing runtime errors
while preserving existing behavior.

All tests pass.
Thanks!
