### PR TITLE
fix(markdown-common): retain empty nodes arrays in AST to satisfy strict=true in concerto-v4

### DIFF
--- a/packages/markdown-cicero/lib/__snapshots__/CommonMarkSpec.test.js.snap
+++ b/packages/markdown-cicero/lib/__snapshots__/CommonMarkSpec.test.js.snap
@@ -484,14 +484,17 @@ exports[`markdown-spec converts ATX headings-49 to concerto 1`] = `
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
       "level": "2",
+      "nodes": [],
     },
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
       "level": "1",
+      "nodes": [],
     },
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
       "level": "3",
+      "nodes": [],
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -1656,6 +1659,7 @@ exports[`markdown-spec converts Block quotes-209 to concerto 1`] = `
   "nodes": [
     {
       "$class": "org.accordproject.commonmark@0.5.0.BlockQuote",
+      "nodes": [],
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -1668,6 +1672,7 @@ exports[`markdown-spec converts Block quotes-210 to concerto 1`] = `
   "nodes": [
     {
       "$class": "org.accordproject.commonmark@0.5.0.BlockQuote",
+      "nodes": [],
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -10394,6 +10399,7 @@ exports[`markdown-spec converts Link reference definitions-187 to concerto 1`] =
     },
     {
       "$class": "org.accordproject.commonmark@0.5.0.BlockQuote",
+      "nodes": [],
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -13982,6 +13988,7 @@ exports[`markdown-spec converts List items-250 to concerto 1`] = `
       "nodes": [
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
       ],
       "tight": "true",
@@ -14024,6 +14031,7 @@ exports[`markdown-spec converts List items-251 to concerto 1`] = `
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
@@ -14071,6 +14079,7 @@ exports[`markdown-spec converts List items-252 to concerto 1`] = `
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
@@ -14119,6 +14128,7 @@ exports[`markdown-spec converts List items-253 to concerto 1`] = `
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
@@ -14153,6 +14163,7 @@ exports[`markdown-spec converts List items-254 to concerto 1`] = `
       "nodes": [
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
       ],
       "tight": "true",
@@ -15940,6 +15951,7 @@ exports[`markdown-spec converts Lists-285 to concerto 1`] = `
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",

--- a/packages/markdown-common/lib/FromMarkdownIt.js
+++ b/packages/markdown-common/lib/FromMarkdownIt.js
@@ -173,11 +173,6 @@ class FromMarkdownIt {
             } else if (rule.close) {
                 const node = stack.pop();
                 if (rule.exit) { rule.exit(node,token,FromMarkdownIt.inlineCallback(rules)); }
-                if (token.type !== 'paragraph_close') {
-                    if (node.nodes.length === 0) {
-                        delete node.nodes;
-                    }
-                }
             }
         }
 

--- a/packages/markdown-common/lib/__snapshots__/CommonMarkSpec.test.js.snap
+++ b/packages/markdown-common/lib/__snapshots__/CommonMarkSpec.test.js.snap
@@ -484,14 +484,17 @@ exports[`markdown-spec converts ATX headings-49 to concerto JSON 1`] = `
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
       "level": "2",
+      "nodes": [],
     },
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
       "level": "1",
+      "nodes": [],
     },
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
       "level": "3",
+      "nodes": [],
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -1656,6 +1659,7 @@ exports[`markdown-spec converts Block quotes-209 to concerto JSON 1`] = `
   "nodes": [
     {
       "$class": "org.accordproject.commonmark@0.5.0.BlockQuote",
+      "nodes": [],
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -1668,6 +1672,7 @@ exports[`markdown-spec converts Block quotes-210 to concerto JSON 1`] = `
   "nodes": [
     {
       "$class": "org.accordproject.commonmark@0.5.0.BlockQuote",
+      "nodes": [],
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -10394,6 +10399,7 @@ exports[`markdown-spec converts Link reference definitions-187 to concerto JSON 
     },
     {
       "$class": "org.accordproject.commonmark@0.5.0.BlockQuote",
+      "nodes": [],
     },
   ],
   "xmlns": "http://commonmark.org/xml/1.0",
@@ -13982,6 +13988,7 @@ exports[`markdown-spec converts List items-250 to concerto JSON 1`] = `
       "nodes": [
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
       ],
       "tight": "true",
@@ -14024,6 +14031,7 @@ exports[`markdown-spec converts List items-251 to concerto JSON 1`] = `
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
@@ -14071,6 +14079,7 @@ exports[`markdown-spec converts List items-252 to concerto JSON 1`] = `
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
@@ -14119,6 +14128,7 @@ exports[`markdown-spec converts List items-253 to concerto JSON 1`] = `
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
@@ -14153,6 +14163,7 @@ exports[`markdown-spec converts List items-254 to concerto JSON 1`] = `
       "nodes": [
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
       ],
       "tight": "true",
@@ -15940,6 +15951,7 @@ exports[`markdown-spec converts Lists-285 to concerto JSON 1`] = `
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",
+          "nodes": [],
         },
         {
           "$class": "org.accordproject.commonmark@0.5.0.Item",

--- a/packages/markdown-common/lib/__snapshots__/CommonMarkTransformer.test.js.snap
+++ b/packages/markdown-common/lib/__snapshots__/CommonMarkTransformer.test.js.snap
@@ -1283,10 +1283,12 @@ exports[`markdown converts heading-empty.md to concerto JSON 1`] = `
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
       "level": "1",
+      "nodes": [],
     },
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
       "level": "2",
+      "nodes": [],
     },
     {
       "$class": "org.accordproject.commonmark@0.5.0.Heading",
@@ -1956,6 +1958,7 @@ exports[`markdown converts miniblockquote2.md to concerto JSON 1`] = `
               "nodes": [
                 {
                   "$class": "org.accordproject.commonmark@0.5.0.Item",
+                  "nodes": [],
                 },
               ],
               "tight": "true",
@@ -1971,6 +1974,7 @@ exports[`markdown converts miniblockquote2.md to concerto JSON 1`] = `
               "nodes": [
                 {
                   "$class": "org.accordproject.commonmark@0.5.0.Item",
+                  "nodes": [],
                 },
               ],
               "tight": "true",


### PR DESCRIPTION
### Description
fixes #651 
This PR fixes a critical AST validation crash that occurs when using  Concerto v4 engine (specifically `4.0.0-beta.1` and later) alongside `markdown-transform`. I uncovered this bug 2-3 weeks ago and and the fix was easier than I anticipated!

**The Root Cause:**
As described in the issue:
In `packages/markdown-common/lib/FromMarkdownIt.js` (`blockToCommonMark`), the parser was explicitly deleting the `nodes` array if a markdown element (like an empty clause, list, or blockquote) had no children. While Concerto v3 permitted this "lazy AST" where the array was simply `undefined`, the new strict type-checking in Concerto v4 throws a fatal `ValidationException: Expected property 'nodes' to be an array` because `nodes` is defined as a mandatory array in the metamodel.

**The Fix:**
Removed the aggressive deletion block (`delete node.nodes`) in `FromMarkdownIt.js` so that empty elements correctly retain an empty array (`"nodes": []`). 

### Testing / Validation
- Tested against Concerto v3: Fully backward compatible. Ran the full test suite and updated Jest snapshots successfully.
- Tested against Concerto v4: Prevents the `ValidationException` crash in strict parsing environments.

**Standalone Script Output Proof:**
I made a script to directly test this:
By feeding an empty clause (`{{#clause testClause}}\n{{/clause}}`) into `CiceroMarkTransformer`, we can see the exact structural change to the AST:

**Before (Fails v4 Validation):**
```json
--- RAW AST OUTPUT ---
{
  "$class": "org.accordproject.ciceromark@0.6.0.Clause",
  "name": "testClause"
}
❌ BUG REPRODUCED: 'nodes' array was deleted!
```
**After (Passes v4 Validation):**
```json
--- RAW AST OUTPUT ---
{
  "$class": "org.accordproject.ciceromark@0.6.0.Clause",
  "name": "testClause",
  "nodes": []
}
✅ FIX WORKS: 'nodes' array is present!
```