### PR TITLE
chore: add TemplateMark dingus retirement page

### DIFF
--- a/support/templatemark-dingus-retired/README.md
+++ b/support/templatemark-dingus-retired/README.md
@@ -1,0 +1,28 @@
+# TemplateMark Dingus Retirement Page
+
+This folder contains the static replacement for the retired legacy
+TemplateMark dingus formerly served at
+`https://templatemark-dingus.netlify.app/`.
+
+Deploy this directory as a static site. The published page intentionally
+contains no JavaScript bundles, PDF logic, or third-party scripts.
+
+## Deployment Handoff
+
+The currently authenticated Netlify account used during implementation does
+not have access to the existing `templatemark-dingus` site. A Netlify user
+who can administer that site should publish this folder to production.
+
+Example CLI flow for the site owner:
+
+```bash
+npx netlify login
+npx netlify link --id <templatemark-dingus-site-id>
+npx netlify deploy --prod --dir support/templatemark-dingus-retired
+```
+
+After deployment, confirm:
+
+- the live page no longer references the old `index.js` bundle
+- the live page no longer references `https://twemoji.maxcdn.com/twemoji.min.js`
+- the archival notice and links render correctly

--- a/support/templatemark-dingus-retired/index.html
+++ b/support/templatemark-dingus-retired/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TemplateMark Dingus Archived</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main class="page">
+      <p class="eyebrow">Accord Project</p>
+      <h1>TemplateMark dingus archived</h1>
+      <p class="lede">
+        The legacy TemplateMark dingus is no longer supported.
+      </p>
+      <p>
+        This demo depended on historical packages that were removed from
+        <code>markdown-transform</code>, including
+        <code>packages/dingus</code> and <code>packages/markdown-pdf</code>.
+      </p>
+      <p>
+        The public site previously served the legacy <code>v0.16.2</code>
+        bundle, which is why issue #655 reported a blank preview pane.
+      </p>
+      <div class="actions">
+        <a href="https://github.com/accordproject/markdown-transform">View repository</a>
+        <a href="https://github.com/accordproject/markdown-transform/issues/655">View issue #655</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/support/templatemark-dingus-retired/issue-655-close-comment.md
+++ b/support/templatemark-dingus-retired/issue-655-close-comment.md
@@ -1,0 +1,9 @@
+Issue #655 was valid for the stale legacy TemplateMark dingus deployment.
+
+The live site was still serving the historical `v0.16.2` bundle, which pulled
+in the browser-unsafe `@accordproject/markdown-pdf` root import chain and also
+referenced the obsolete `https://twemoji.maxcdn.com/twemoji.min.js` script.
+
+The supported resolution was to retire the legacy demo rather than restore
+packages that were intentionally removed from `markdown-transform`. The live
+site now serves a static archival notice instead of the old interactive dingus.

--- a/support/templatemark-dingus-retired/styles.css
+++ b/support/templatemark-dingus-retired/styles.css
@@ -1,0 +1,108 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f1e3;
+  --panel: rgba(255, 255, 255, 0.72);
+  --text: #1f2a2e;
+  --muted: #5b676d;
+  --accent: #0f766e;
+  --border: rgba(31, 42, 46, 0.12);
+  --shadow: 0 24px 60px rgba(23, 39, 48, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at top left, rgba(15, 118, 110, 0.16), transparent 28%),
+    linear-gradient(160deg, #f9f5eb 0%, #efe5cf 100%);
+}
+
+.page {
+  width: min(720px, calc(100% - 2rem));
+  margin: 8vh auto;
+  padding: 2.75rem;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.05;
+}
+
+.lede {
+  margin-top: 1rem;
+  font-size: 1.3rem;
+  color: var(--muted);
+}
+
+p {
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.92em;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  margin-top: 2rem;
+}
+
+.actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.7rem 1.1rem;
+  border: 1px solid rgba(15, 118, 110, 0.18);
+  border-radius: 999px;
+  color: var(--accent);
+  background: rgba(255, 255, 255, 0.78);
+  text-decoration: none;
+}
+
+.actions a:hover,
+.actions a:focus-visible {
+  border-color: rgba(15, 118, 110, 0.5);
+  background: #ffffff;
+}
+
+@media (max-width: 640px) {
+  .page {
+    margin: 2rem auto;
+    padding: 1.5rem;
+    border-radius: 20px;
+  }
+
+  .lede {
+    font-size: 1.15rem;
+  }
+
+  .actions a {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
# Closes #655

Adds a repo-tracked retirement page for the legacy TemplateMark dingus so the stale `v0.16.2` demo can be replaced with a static archival notice instead of restoring removed packages.

### Changes
- add `support/templatemark-dingus-retired/` with a static replacement page and stylesheet for the retired dingus site
- add deployment handoff notes and an issue-close comment template for the Netlify site owner who will replace the live demo

### Flags
- this PR does not itself redeploy `https://templatemark-dingus.netlify.app/`; the current Netlify account in this environment does not have access to the existing site
- no unit or integration tests were added because this change is a static retirement page; the page was verified locally in the in-app browser

### Screenshots or Video
<img width="870" height="572" alt="Screenshot 2026-05-09 at 8 57 41 PM" src="https://github.com/user-attachments/assets/e6edc5c3-ba69-4d1e-b1aa-37132bc2728f" />

### Related Issues
- Issue #655


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/main/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` from `Rishabh060105:Rishabh060105/retire-templatemark-dingus`
[index.html](https://github.com/user-attachments/files/27553822/index.html)
