### PR TITLE
fix(*): align remaining types and publish runtime follow-up

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/packages/markdown-html/src/HtmlTransformer.js
+++ b/packages/markdown-html/src/HtmlTransformer.js
@@ -14,6 +14,10 @@
 
 'use strict';
 
+/** @typedef {import('@accordproject/markdown-common/types/model/commonmark').IDocument} IDocument */
+/** @typedef {import('@accordproject/concerto-core').Typed} Typed */
+/** @typedef {IDocument|Typed} HtmlInput */
+
 const ToHtmlStringVisitor = require('./ToHtmlStringVisitor');
 const ToCiceroMarkVisitor = require('./ToCiceroMarkVisitor');
 const CiceroMarkTransformer = require('@accordproject/markdown-cicero').CiceroMarkTransformer;
@@ -34,7 +38,7 @@ class HtmlTransformer {
 
     /**
      * Converts a CiceroMark DOM to an html string
-     * @param {object} input - CiceroMark DOM object
+     * @param {HtmlInput} input - CiceroMark DOM object
      * @returns {string} the html string
      */
     toHtml(input) {
@@ -55,7 +59,7 @@ class HtmlTransformer {
     /**
      * Converts an html string to a CiceroMark DOM
      * @param {string} input - html string
-     * @returns {object} CiceroMark DOM
+     * @returns {IDocument} CiceroMark DOM
      */
     toCiceroMark(input) {
         const visitor = new ToCiceroMarkVisitor(this.options);

--- a/packages/markdown-html/types/lib/HtmlTransformer.d.ts
+++ b/packages/markdown-html/types/lib/HtmlTransformer.d.ts
@@ -12,14 +12,20 @@ declare class HtmlTransformer {
     ciceroMarkTransformer: import("@accordproject/markdown-cicero/types/lib/CiceroMarkTransformer");
     /**
      * Converts a CiceroMark DOM to an html string
-     * @param {object} input - CiceroMark DOM object
+     * @param {HtmlInput} input - CiceroMark DOM object
      * @returns {string} the html string
      */
-    toHtml(input: object): string;
+    toHtml(input: HtmlInput): string;
     /**
      * Converts an html string to a CiceroMark DOM
      * @param {string} input - html string
-     * @returns {object} CiceroMark DOM
+     * @returns {IDocument} CiceroMark DOM
      */
-    toCiceroMark(input: string): object;
+    toCiceroMark(input: string): IDocument;
 }
+declare namespace HtmlTransformer {
+    export { IDocument, Typed, HtmlInput };
+}
+type IDocument = import("@accordproject/markdown-common/types/model/commonmark").IDocument;
+type Typed = import("@accordproject/concerto-core").Typed;
+type HtmlInput = IDocument | Typed;

--- a/packages/markdown-template/lib/TemplateMarkTransformer.js
+++ b/packages/markdown-template/lib/TemplateMarkTransformer.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+/** @typedef {import('@accordproject/concerto-core').Serializer} Serializer */
 var {
   templateMarkManager,
   templateToTokens,
@@ -93,7 +94,7 @@ class TemplateMarkTransformer {
 
   /**
    * Get TemplateMark serializer
-   * @return {object} templatemark serializer
+   * @return {Serializer} templatemark serializer
    */
   getSerializer() {
     return templateMarkManager.serializer;

--- a/packages/markdown-template/src/TemplateMarkTransformer.js
+++ b/packages/markdown-template/src/TemplateMarkTransformer.js
@@ -14,6 +14,8 @@
 
 'use strict';
 
+/** @typedef {import('@accordproject/concerto-core').Serializer} Serializer */
+
 const {
     templateMarkManager,
     templateToTokens,
@@ -95,7 +97,7 @@ class TemplateMarkTransformer {
 
     /**
      * Get TemplateMark serializer
-     * @return {object} templatemark serializer
+     * @return {Serializer} templatemark serializer
      */
     getSerializer() {
         return templateMarkManager.serializer;

--- a/packages/markdown-template/types/lib/TemplateMarkTransformer.d.ts
+++ b/packages/markdown-template/types/lib/TemplateMarkTransformer.d.ts
@@ -46,7 +46,11 @@ declare class TemplateMarkTransformer {
     toMarkdownTemplate(input: object): string;
     /**
      * Get TemplateMark serializer
-     * @return {object} templatemark serializer
+     * @return {Serializer} templatemark serializer
      */
-    getSerializer(): object;
+    getSerializer(): Serializer;
 }
+declare namespace TemplateMarkTransformer {
+    export { Serializer };
+}
+type Serializer = import("@accordproject/concerto-core").Serializer;


### PR DESCRIPTION
# Follow-up to #669

This PR is a focused follow-up on top of #669 to address the remaining gaps found during review.

### Changes
- Updated `.github/workflows/publish.yml` to use Node 22 so the release workflow matches the new `engines.node >=22` requirement introduced in #669
- Tightened the remaining weak public types by updating `HtmlTransformer` to emit `HtmlInput` / `IDocument` and `TemplateMarkTransformer.getSerializer()` to emit `Serializer`

### Flags
- This PR is intentionally based on `feat/tighten-typescript-types` so the diff stays limited to the follow-up fixes instead of duplicating #669
- `packages/markdown-template` still has the existing `no-console` lint warnings in its source, but this follow-up does not introduce any new lint errors

### Screenshots or Video
- Not applicable

### Related Issues
- Issue #668
- Pull Request #669

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/main/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `feat/tighten-typescript-types` from `Rishabh060105/pr669-followup-fixes`

### Validation
- `npm run build --workspace packages/markdown-template`
- `npm run build --workspace packages/markdown-html`
- `npm run lint --workspace packages/markdown-template`
- `npm run lint --workspace packages/markdown-html`
- `npm test --workspace packages/markdown-template`
- `npm test --workspace packages/markdown-html`
